### PR TITLE
feat: Improve model exports

### DIFF
--- a/media_kit/lib/media_kit.dart
+++ b/media_kit/lib/media_kit.dart
@@ -7,17 +7,20 @@
 // ignore_for_file: camel_case_types
 
 export 'package:media_kit/src/media_kit.dart';
-export 'package:media_kit/src/player/player.dart';
+
+export 'package:media_kit/src/models/audio_device.dart';
+export 'package:media_kit/src/models/audio_params.dart';
+export 'package:media_kit/src/models/media/media.dart';
+export 'package:media_kit/src/models/player_state.dart';
+export 'package:media_kit/src/models/player_stream.dart';
+export 'package:media_kit/src/models/playlist.dart';
+export 'package:media_kit/src/models/playlist_mode.dart';
+export 'package:media_kit/src/models/track.dart';
+
+export 'package:media_kit/src/legacy.dart';
+
 export 'package:media_kit/src/player/platform_player.dart';
+export 'package:media_kit/src/player/player.dart';
 
 export 'package:media_kit/src/player/native/player/player.dart';
 export 'package:media_kit/src/player/web/player/player.dart';
-
-export 'package:media_kit/src/models/track.dart';
-export 'package:media_kit/src/models/playlist.dart';
-export 'package:media_kit/src/models/media/media.dart';
-export 'package:media_kit/src/models/audio_device.dart';
-export 'package:media_kit/src/models/audio_params.dart';
-export 'package:media_kit/src/models/playlist_mode.dart';
-
-export 'package:media_kit/src/legacy.dart';


### PR DESCRIPTION
- Exports `PlayerState` and `PlayerStream` since they are public APIs and their `Type` cannot be referenced outside. (e.g. `final PlayerState state = player.state;`)
- Sort exports alphabetically.