### PR TITLE
feat(linux): mimalloc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1673,20 +1673,32 @@ During the build phase, the following warnings are not critical and cannot be si
 
 ### GNU/Linux
 
-System shared libraries from distribution specific user-installed packages are used by-default. You can install these as follows:
+#### Install libmpv
 
-#### Ubuntu/Debian
+System shared libraries from distribution specific user-installed packages are used by-default. **This is how GNU/Linux works.** You can install these as follows:
+
+##### Ubuntu/Debian
 
 ```bash
 sudo apt install libmpv-dev mpv
 ```
 
-#### Packaging
+##### Packaging
 
 There are other ways to bundle these within your app package e.g. within Snap or Flatpak. Few examples:
 
 - [Celluloid](https://github.com/celluloid-player/celluloid/blob/master/flatpak/io.github.celluloid_player.Celluloid.json)
 - [VidCutter](https://github.com/ozmartian/vidcutter/tree/master/\_packaging)
+
+#### Utilize [mimalloc](https://github.com/microsoft/mimalloc)
+
+You should consider replacing the default memory allocator with [mimalloc](https://github.com/microsoft/mimalloc) for [avoiding memory leaks](https://github.com/media-kit/media-kit/issues/68).
+
+This is as simple as [adding one line to `linux/CMakeLists.txt`](https://github.com/media-kit/media-kit/blob/d02a97ce70b316207db024401fb99e3f4509a250/media_kit_test/linux/CMakeLists.txt#L92-L94):
+
+```cmake
+target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
+```
 
 ### Web
 

--- a/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
+++ b/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
@@ -35,3 +35,59 @@ set(
   ""
   PARENT_SCOPE
 )
+
+
+# We use the mimalloc's object file (mimalloc.o) & link the final executable with it.
+# This ensures that the standard malloc interface resolves to the mimalloc library.
+#
+# Refer to "Static Override" section in mimalloc's documentation:
+# https://github.com/microsoft/mimalloc#static-override
+
+# ------------------------------------------------------------------------------
+
+set(MIMALLOC "mimalloc-2.1.2.tar.gz")
+
+set(MIMALLOC_URL "https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.2.tar.gz")
+set(MIMALLOC_MD5 "5179c8f5cf1237d2300e2d8559a7bc55")
+
+set(MIMALLOC_ARCHIVE "${CMAKE_BINARY_DIR}/${MIMALLOC}")
+set(MIMALLOC_SRC "${CMAKE_BINARY_DIR}/mimalloc")
+
+# Download
+if(NOT EXISTS ${MIMALLOC_ARCHIVE})
+  message(STATUS "Downloading ${MIMALLOC}...")
+  file(DOWNLOAD ${MIMALLOC_URL} ${MIMALLOC_ARCHIVE})
+  message(STATUS "Downloaded ${MIMALLOC}...")
+endif()
+
+# Verify
+file(MD5 ${MIMALLOC_ARCHIVE} MIMALLOC_ARCHIVE_MD5)
+
+if(MIMALLOC_MD5 STREQUAL MIMALLOC_ARCHIVE_MD5)
+  message(STATUS "${MIMALLOC} verification successful.")
+else()
+  message(FATAL_ERROR "${MIMALLOC} integrity check failed.")
+endif()
+
+# Extract
+# https://stackoverflow.com/a/19859882/12825435
+set(MIMALLOC_LIB "${MIMALLOC_SRC}/out/release/mimalloc.o" CACHE INTERNAL "")
+
+if(NOT EXISTS ${MIMALLOC_SRC})
+  message(STATUS "Extracting ${MIMALLOC}...")
+  make_directory("${MIMALLOC_SRC}")
+  add_custom_command(
+    OUTPUT ${MIMALLOC_LIB}
+    COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${MIMALLOC_ARCHIVE}\""
+    # add_subdirectory() is too much work. Alternatively building it through command line.
+    COMMAND "mkdir" "-p" "out/release"
+    COMMAND "cd" "out/release"
+    COMMAND "${CMAKE_COMMAND}" "../../mimalloc-2.1.2"
+    COMMAND "make"
+    WORKING_DIRECTORY "${MIMALLOC_SRC}"
+  )
+endif()
+
+# ------------------------------------------------------------------------------
+
+add_custom_target("MIMALLOC_TARGET" ALL DEPENDS ${MIMALLOC_LIB})

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -1666,20 +1666,32 @@ During the build phase, the following warnings are not critical and cannot be si
 
 ### GNU/Linux
 
-System shared libraries from distribution specific user-installed packages are used by-default. You can install these as follows:
+#### Install libmpv
 
-#### Ubuntu/Debian
+System shared libraries from distribution specific user-installed packages are used by-default. **This is how GNU/Linux works.** You can install these as follows:
+
+##### Ubuntu/Debian
 
 ```bash
 sudo apt install libmpv-dev mpv
 ```
 
-#### Packaging
+##### Packaging
 
 There are other ways to bundle these within your app package e.g. within Snap or Flatpak. Few examples:
 
 - [Celluloid](https://github.com/celluloid-player/celluloid/blob/master/flatpak/io.github.celluloid_player.Celluloid.json)
 - [VidCutter](https://github.com/ozmartian/vidcutter/tree/master/\_packaging)
+
+#### Utilize [mimalloc](https://github.com/microsoft/mimalloc)
+
+You should consider replacing the default memory allocator with [mimalloc](https://github.com/microsoft/mimalloc) for [avoiding memory leaks](https://github.com/media-kit/media-kit/issues/68).
+
+This is as simple as [adding one line to `linux/CMakeLists.txt`](https://github.com/media-kit/media-kit/blob/d02a97ce70b316207db024401fb99e3f4509a250/media_kit_test/linux/CMakeLists.txt#L92-L94):
+
+```cmake
+target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
+```
 
 ### Web
 

--- a/media_kit_test/linux/CMakeLists.txt
+++ b/media_kit_test/linux/CMakeLists.txt
@@ -90,6 +90,7 @@ set_target_properties(${BINARY_NAME}
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build

--- a/media_kit_video/linux/video_output.cc
+++ b/media_kit_video/linux/video_output.cc
@@ -160,7 +160,6 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
             g_print("media_kit: VideoOutput: Using H/W rendering.\n");
           }
         }
-        gdk_gl_context_clear_current();
       }
     }
     if (error) {


### PR DESCRIPTION
A continuation of #319. Originally explored as part of #68.

For enabling [mimalloc](https://github.com/microsoft/mimalloc), one must add following line to `linux/CMakeLists.txt`:

https://github.com/media-kit/media-kit/blob/d02a97ce70b316207db024401fb99e3f4509a250/media_kit_test/linux/CMakeLists.txt#L92-L94

This replaces all `malloc`/`calloc`/`free`/`new`/`delete` calls in application (for the good).