### PR TITLE
fix(darwin): fix CRLF added by Flutter packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ dependencies:
   media_kit_native_event_loop: ^1.0.7            # Support for higher number of concurrent instances & better performance.
   
   media_kit_libs_android_video: ^1.3.0           # Android package for video native libraries.
-  media_kit_libs_ios_video: ^1.1.0               # iOS package for video native libraries.
-  media_kit_libs_macos_video: ^1.1.0             # macOS package for video native libraries.
+  media_kit_libs_ios_video: ^1.1.1               # iOS package for video native libraries.
+  media_kit_libs_macos_video: ^1.1.1             # macOS package for video native libraries.
   media_kit_libs_windows_video: ^1.0.5           # Windows package for video native libraries.
   media_kit_libs_linux: ^1.1.0                   # GNU/Linux dependency package.
 ```
@@ -68,8 +68,8 @@ dependencies:
   media_kit_native_event_loop: ^1.0.7            # Support for higher number of concurrent instances & better performance.
   
   media_kit_libs_android_audio: ^1.3.0           # Android package for audio native libraries.
-  media_kit_libs_ios_audio: ^1.1.0               # iOS package for audio native libraries.
-  media_kit_libs_macos_audio: ^1.1.0             # macOS package for audio native libraries.
+  media_kit_libs_ios_audio: ^1.1.1               # iOS package for audio native libraries.
+  media_kit_libs_macos_audio: ^1.1.1             # macOS package for audio native libraries.
   media_kit_libs_windows_audio: ^1.0.5           # Windows package for audio native libraries.
   media_kit_libs_linux: ^1.1.0                   # GNU/Linux dependency package.
 ```

--- a/libs/ios/media_kit_libs_ios_audio/CHANGELOG.md
+++ b/libs/ios/media_kit_libs_ios_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- fix: fix CRLF line terminator added by Flutter packaging (#338)
+
 ## 1.1.0
 
 - build: bump libs to default flavor

--- a/libs/ios/media_kit_libs_ios_audio/example/README.md
+++ b/libs/ios/media_kit_libs_ios_audio/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_ios_audio: ^1.1.0
+  media_kit_libs_ios_audio: ^1.1.1
 ```
 
 This will automatically bundle required shared libraries for audio playback on iOS.

--- a/libs/ios/media_kit_libs_ios_audio/ios/Makefile
+++ b/libs/ios/media_kit_libs_ios_audio/ios/Makefile
@@ -26,6 +26,7 @@ Frameworks/*.xcframework: .cache/xcframeworks/libmpv-xcframeworks-ios-universal.
 Frameworks/.symlinks: Frameworks/*.xcframework
 	rm -rf Frameworks/.symlinks
 	mkdir -p Frameworks/.symlinks/mpv
+	sed -i '' 's/\r$$//g' create_framework_symlinks.sh # remove CRLF line terminator added by Flutter packaging (https://github.com/media-kit/media-kit/issues/338)
 	sh create_framework_symlinks.sh Frameworks/Mpv.xcframework Frameworks/.symlinks/mpv
 
 .PHONY: clean

--- a/libs/ios/media_kit_libs_ios_audio/pubspec.yaml
+++ b/libs/ios/media_kit_libs_ios_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_ios_audio
 description: iOS package providing audio native libraries for package:media_kit.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 funding:

--- a/libs/ios/media_kit_libs_ios_video/CHANGELOG.md
+++ b/libs/ios/media_kit_libs_ios_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- fix: fix CRLF line terminator added by Flutter packaging (#338)
+
 ## 1.1.0
 
 - build: bump libs to default flavor

--- a/libs/ios/media_kit_libs_ios_video/example/README.md
+++ b/libs/ios/media_kit_libs_ios_video/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_ios_video: ^1.1.0
+  media_kit_libs_ios_video: ^1.1.1
 ```
 
 This will automatically bundle required shared libraries for video (& audio) playback on iOS.

--- a/libs/ios/media_kit_libs_ios_video/ios/Makefile
+++ b/libs/ios/media_kit_libs_ios_video/ios/Makefile
@@ -26,6 +26,7 @@ Frameworks/*.xcframework: .cache/xcframeworks/libmpv-xcframeworks-ios-universal.
 Frameworks/.symlinks: Frameworks/*.xcframework
 	rm -rf Frameworks/.symlinks
 	mkdir -p Frameworks/.symlinks/mpv
+	sed -i '' 's/\r$$//g' create_framework_symlinks.sh # remove CRLF line terminator added by Flutter packaging (https://github.com/media-kit/media-kit/issues/338)
 	sh create_framework_symlinks.sh Frameworks/Mpv.xcframework Frameworks/.symlinks/mpv
 
 .PHONY: clean

--- a/libs/ios/media_kit_libs_ios_video/pubspec.yaml
+++ b/libs/ios/media_kit_libs_ios_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_ios_video
 description: iOS package providing video (& audio) native libraries for package:media_kit.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 funding:

--- a/libs/macos/media_kit_libs_macos_audio/CHANGELOG.md
+++ b/libs/macos/media_kit_libs_macos_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- fix: fix CRLF line terminator added by Flutter packaging (#338)
+
 ## 1.1.0
 
 - build: bump libs to default flavor

--- a/libs/macos/media_kit_libs_macos_audio/example/README.md
+++ b/libs/macos/media_kit_libs_macos_audio/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_macos_audio: ^1.1.0
+  media_kit_libs_macos_audio: ^1.1.1
 ```
 
 This will automatically bundle required shared libraries for audio playback on macOS.

--- a/libs/macos/media_kit_libs_macos_audio/macos/Makefile
+++ b/libs/macos/media_kit_libs_macos_audio/macos/Makefile
@@ -26,6 +26,7 @@ Frameworks/*.xcframework: .cache/xcframeworks/libmpv-xcframeworks-macos-universa
 Frameworks/.symlinks: Frameworks/*.xcframework
 	rm -rf Frameworks/.symlinks
 	mkdir -p Frameworks/.symlinks/mpv
+	sed -i '' 's/\r$$//g' create_framework_symlinks.sh # remove CRLF line terminator added by Flutter packaging (https://github.com/media-kit/media-kit/issues/338)
 	sh create_framework_symlinks.sh Frameworks/Mpv.xcframework Frameworks/.symlinks/mpv
 
 .PHONY: clean

--- a/libs/macos/media_kit_libs_macos_audio/pubspec.yaml
+++ b/libs/macos/media_kit_libs_macos_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_macos_audio
 description: macOS package providing audio native libraries for package:media_kit.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 funding:

--- a/libs/macos/media_kit_libs_macos_video/CHANGELOG.md
+++ b/libs/macos/media_kit_libs_macos_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- fix: fix CRLF line terminator added by Flutter packaging (#338)
+
 ## 1.1.0
 
 - build: bump libs to default flavor

--- a/libs/macos/media_kit_libs_macos_video/example/README.md
+++ b/libs/macos/media_kit_libs_macos_video/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_macos_video: ^1.1.0
+  media_kit_libs_macos_video: ^1.1.1
 ```
 
 This will automatically bundle required shared libraries for video (& audio) playback on macOS.

--- a/libs/macos/media_kit_libs_macos_video/macos/Makefile
+++ b/libs/macos/media_kit_libs_macos_video/macos/Makefile
@@ -26,6 +26,7 @@ Frameworks/*.xcframework: .cache/xcframeworks/libmpv-xcframeworks-macos-universa
 Frameworks/.symlinks: Frameworks/*.xcframework
 	rm -rf Frameworks/.symlinks
 	mkdir -p Frameworks/.symlinks/mpv
+	sed -i '' 's/\r$$//g' create_framework_symlinks.sh # remove CRLF line terminator added by Flutter packaging (https://github.com/media-kit/media-kit/issues/338)
 	sh create_framework_symlinks.sh Frameworks/Mpv.xcframework Frameworks/.symlinks/mpv
 
 .PHONY: clean

--- a/libs/macos/media_kit_libs_macos_video/pubspec.yaml
+++ b/libs/macos/media_kit_libs_macos_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_macos_video
 description: macOS package providing video (& audio) native libraries for package:media_kit.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 funding:

--- a/media_kit/CHANGELOG.md
+++ b/media_kit/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.2+1
+
+- docs: document updated
+  - `media_kit_libs_ios_audio`
+  - `media_kit_libs_ios_video`
+  - `media_kit_libs_macos_audio`
+  - `media_kit_libs_macos_video`
+
 ## 1.1.2
 
 - feat: export `PlayerState` & `PlayerStream`

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -45,8 +45,8 @@ dependencies:
   media_kit_native_event_loop: ^1.0.7            # Support for higher number of concurrent instances & better performance.
   
   media_kit_libs_android_video: ^1.3.0           # Android package for video native libraries.
-  media_kit_libs_ios_video: ^1.1.0               # iOS package for video native libraries.
-  media_kit_libs_macos_video: ^1.1.0             # macOS package for video native libraries.
+  media_kit_libs_ios_video: ^1.1.1               # iOS package for video native libraries.
+  media_kit_libs_macos_video: ^1.1.1             # macOS package for video native libraries.
   media_kit_libs_windows_video: ^1.0.5           # Windows package for video native libraries.
   media_kit_libs_linux: ^1.1.0                   # GNU/Linux dependency package.
 ```
@@ -60,8 +60,8 @@ dependencies:
   media_kit_native_event_loop: ^1.0.7            # Support for higher number of concurrent instances & better performance.
   
   media_kit_libs_android_audio: ^1.3.0           # Android package for audio native libraries.
-  media_kit_libs_ios_audio: ^1.1.0               # iOS package for audio native libraries.
-  media_kit_libs_macos_audio: ^1.1.0             # macOS package for audio native libraries.
+  media_kit_libs_ios_audio: ^1.1.1               # iOS package for audio native libraries.
+  media_kit_libs_macos_audio: ^1.1.1             # macOS package for audio native libraries.
   media_kit_libs_windows_audio: ^1.0.5           # Windows package for audio native libraries.
   media_kit_libs_linux: ^1.1.0                   # GNU/Linux dependency package.
 ```


### PR DESCRIPTION
Flutter or Windows changes the encoding of the `create_framework_symlinks.sh` script, making it unusable.

Fix #338