### PR TITLE
feat: `NativePlayer.observeProperty` & `NativePlayer.unobserveProperty`

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -1993,6 +1993,11 @@ class NativePlayer extends PlatformPlayer {
               errorController.add(text);
             }
           }
+          if (prefix == 'cplayer') {
+            if (!errorController.isClosed) {
+              errorController.add(text);
+            }
+          }
         }
         // --------------------------------------------------
       }


### PR DESCRIPTION
A new forbidden API that might be useful in some advanced use-cases. I have added relevant unit-tests.

**Example Usage:**

```dart
import 'package:media_kit/media_kit.dart';

Future<void> main() async {
  MediaKit.ensureInitialized();
  final player = Player();
  await (player.platform as NativePlayer).observeProperty(
    'demuxer-cache-state',
    (data) async {
      print(data);
    },
  );
  await player.open(Media('https://user-images.githubusercontent.com/28951144/229373695-22f88f13-d18f-4288-9bf1-c3e078d83722.mp4'));
}
```

**Example Output:**

```
{"cache-duration":0.000000,"eof":false,"underrun":true,"idle":false,"total-bytes":0,"fw-bytes":0,"raw-input-rate":2362,"debug-low-level-seeks":0,"debug-byte-level-seeks":0,"bof-cached":false,"eof-cached":false,"seekable-ranges":[]}
{"cache-end":11.238458,"reader-pts":0.255420,"cache-duration":10.983039,"eof":false,"underrun":false,"idle":false,"total-bytes":448496,"fw-bytes":434496,"raw-input-rate":2362,"debug-low-level-seeks":0,"debug-byte-level-seeks":0,"debug-ts-last":11.238458,"bof-cached":true,"eof-cached":false,"seekable-ranges":[{"start":-0.023220,"end":11.215238}]}
{"cache-end":26.981587,"reader-pts":0.255420,"cache-duration":26.726168,"eof":false,"underrun":false,"idle":false,"total-bytes":1068112,"fw-bytes":1054112,"raw-input-rate":2362,"debug-low-level-seeks":0,"debug-byte-level-seeks":0,"debug-ts-last":26.981587,"bof-cached":true,"eof-cached":false,"seekable-ranges":[{"start":-0.023220,"end":26.958367}]}
{"cache-end":46.045170,"reader-pts":0.255420,"cache-duration":45.789751,"eof":false,"underrun":false,"idle":false,"total-bytes":1820448,"fw-bytes":1806448,"raw-input-rate":2362,"debug-low-level-seeks":0,"debug-byte-level-seeks":0,"debug-ts-last":46.045170,"bof-cached":true,"eof-cached":false,"seekable-ranges":[{"start":-0.023220,"end":46.021950}]}
{"cache-end":60.046803,"reader-pts":0.325079,"cache-duration":59.721723,"eof":true,"underrun":false,"idle":true,"total-bytes":2372112,"fw-bytes":2354976,"raw-input-rate":2362,"debug-low-level-seeks":0,"debug-byte-level-seeks":0,"debug-ts-last":60.046803,"bof-cached":true,"eof-cached":true,"seekable-ranges":[{"start":-0.023220,"end":60.046803}]}
{"cache-end":60.046803,"reader-pts":1.369977,"cache-duration":58.676825,"eof":true,"underrun":false,"idle":true,"total-bytes":2372112,"fw-bytes":2312880,"raw-input-rate":3383889,"debug-low-level-seeks":0,"debug-byte-level-seeks":0,"debug-ts-last":60.046803,"bof-cached":true,"eof-cached":true,"seekable-ranges":[{"start":-0.023220,"end":60.046803}]}
{"cache-end":60.046803,"reader-pts":1.602177,"cache-duration":58.444626,"eof":true,"underrun":false,"idle":true,"total-bytes":2372112,"fw-bytes":2303712,"raw-input-rate":3383889,"debug-low-level-seeks":0,"debug-byte-level-seeks":0,"debug-ts-last":60.046803,"bof-cached":true,"eof-cached":true,"seekable-ranges":[{"start":-0.023220,"end":60.046803}]}
```

In this case, data received in the listener is JSON. It is expected that API consumers will be self-aware of the properties they observe & the type property will have (thus, accordingly handle it as well). This eliminates the need of exposing every single libmpv property/option inside `PlayerState`/`PlayerStream` for internal/public usage.