### PR TITLE
fix: `pause` during `buffering` makes `Player` not exit `buffering`; fix: `error` stream; test: player-buffering-pause-play; feat: `Video` `resumeUponEnteringForegroundMode`

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -1530,15 +1530,20 @@ class NativePlayer extends PlatformPlayer {
           prop.ref.format == generated.mpv_format.MPV_FORMAT_FLAG) {
         // Check for [isBufferingStateChangeAllowed] because `pause` causes `core-idle` to be fired.
         final buffering = prop.ref.data.cast<Int8>().value == 1;
-        if (isBufferingStateChangeAllowed) {
-          state = state.copyWith(buffering: buffering);
+        if (buffering) {
+          if (isBufferingStateChangeAllowed) {
+            state = state.copyWith(buffering: true);
+            if (!bufferingController.isClosed) {
+              bufferingController.add(true);
+            }
+          }
+        } else {
+          state = state.copyWith(buffering: false);
           if (!bufferingController.isClosed) {
-            bufferingController.add(buffering);
+            bufferingController.add(false);
           }
         }
-        if (buffering) {
-          isBufferingStateChangeAllowed = true;
-        }
+        isBufferingStateChangeAllowed = true;
       }
       if (prop.ref.name.cast<Utf8>().toDartString() == 'paused-for-cache' &&
           prop.ref.format == generated.mpv_format.MPV_FORMAT_FLAG) {

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2133,6 +2133,11 @@ class NativePlayer extends PlatformPlayer {
               errorController.add(text);
             }
           }
+          if (prefix == 'stream') {
+            if (!errorController.isClosed) {
+              errorController.add(text);
+            }
+          }
         }
         // --------------------------------------------------
       }

--- a/media_kit/lib/src/player/native/utils/find_packages.dart
+++ b/media_kit/lib/src/player/native/utils/find_packages.dart
@@ -32,60 +32,62 @@ abstract class FindPackages {
   }
 
   static Future<void> _ensureInitialized(_) async {
-    final script = basename(Platform.script.toFilePath());
-    final executable = basename(Platform.resolvedExecutable);
+    try {
+      final script = basename(Platform.script.toFilePath());
+      final executable = basename(Platform.resolvedExecutable);
 
-    final asset = await File(AssetLoader.load('NOTICES.Z')).readAsBytes_();
-    if (asset != null) {
-      final content = utf8.decode(gzip.decode(asset));
-      final elements = content.split('-' * 80);
-      final names = HashSet<String>();
+      final asset = await File(AssetLoader.load('NOTICES.Z')).readAsBytes_();
+      if (asset != null) {
+        final content = utf8.decode(gzip.decode(asset));
+        final elements = content.split('-' * 80);
+        final names = HashSet<String>();
 
-      for (final element in elements) {
-        bool found = false;
-        final current = HashSet<String>();
-        final lines = element.split('\n');
-        for (final line in lines) {
-          if (line.isNotEmpty) {
-            current.add(line);
-            found = true;
-          } else if (found && line.isEmpty) {
-            break;
-          }
-        }
-        names.addAll(current);
-      }
-
-      final supported = HashSet<String>.of(
-        [
-          'media_kit',
-          'media_kit_video',
-          'media_kit_native_event_loop',
-        ],
-      );
-
-      bool success = true;
-
-      for (final name in names) {
-        if (!script.contains(name) && !executable.contains(name)) {
-          if (name.contains('media_kit')) {
-            if (!name.startsWith('media_kit') && !supported.contains(name)) {
-              success = false;
-              break;
-            }
-          } else if (name.contains('video') && name.contains('player')) {
-            if (!name.contains('video_player') && !name.contains('-')) {
-              success = false;
+        for (final element in elements) {
+          bool found = false;
+          final current = HashSet<String>();
+          final lines = element.split('\n');
+          for (final line in lines) {
+            if (line.isNotEmpty) {
+              current.add(line);
+              found = true;
+            } else if (found && line.isEmpty) {
               break;
             }
           }
+          names.addAll(current);
+        }
+
+        final supported = HashSet<String>.of(
+          [
+            'media_kit',
+            'media_kit_video',
+            'media_kit_native_event_loop',
+          ],
+        );
+
+        bool success = true;
+
+        for (final name in names) {
+          if (!script.contains(name) && !executable.contains(name)) {
+            if (name.contains('media_kit')) {
+              if (!name.startsWith('media_kit') && !supported.contains(name)) {
+                success = false;
+                break;
+              }
+            } else if (name.contains('video') && name.contains('player')) {
+              if (!name.contains('video_player') && !name.contains('-')) {
+                success = false;
+                break;
+              }
+            }
+          }
+        }
+
+        if (!success) {
+          exit(0);
         }
       }
-
-      if (!success) {
-        exit(0);
-      }
-    }
+    } catch (_) {}
   }
 
   static bool _initialized = false;

--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -2342,7 +2342,6 @@ void main() {
     'player-buffering-upon-seek',
     () async {
       final player = Player();
-
       player.stream.buffering.listen((e) => print(e));
 
       expect(
@@ -2371,7 +2370,10 @@ void main() {
         if (event > Duration.zero) {
           // VOLUNTARY DELAY.
           await Future.delayed(const Duration(seconds: 5));
-          await player.seek(event - const Duration(seconds: 10));
+
+          print('Seek');
+
+          await player.seek(event - const Duration(seconds: 30));
         }
       });
 
@@ -2381,11 +2383,82 @@ void main() {
         ),
       );
 
-      await Future.delayed(const Duration(seconds: 30));
+      await Future.delayed(const Duration(minutes: 1));
 
       await player.dispose();
     },
-    timeout: Timeout(const Duration(minutes: 1)),
+    timeout: Timeout(const Duration(minutes: 1, seconds: 30)),
+  );
+  test(
+    'player-buffering-pause-play',
+    () async {
+      // When pausing in buffering state, the player must exit buffering state once resumed.
+      // https://github.com/media-kit/media-kit/issues/367
+      final player = Player();
+
+      player.stream.buffering.listen((e) => print(e));
+
+      expect(
+        player.stream.buffering,
+        emitsInOrder(
+          [
+            // Player.open: buffering = true
+            true,
+            // Player.open: buffering = false
+            false,
+            // Player.seek: buffering = true
+            true,
+            // Player.play: buffering = false
+            false,
+            // EOF
+            true,
+            false,
+            // Player.dispose
+            emitsDone,
+          ],
+        ),
+      );
+
+      // Seek to the end of the stream to trigger buffering.
+      player.stream.duration.listen((event) async {
+        if (event > Duration.zero) {
+          // VOLUNTARY DELAY.
+          await Future.delayed(const Duration(seconds: 5));
+
+          print('Seek');
+
+          await player.seek(event - const Duration(seconds: 30));
+
+          print('Buffering...');
+
+          // Wait until buffering is started.
+          await player.stream.buffering.firstWhere((e) => e);
+
+          print('Wait...');
+          print('Pause');
+
+          await player.pause();
+
+          // VOLUNTARY DELAY.
+          await Future.delayed(const Duration(seconds: 5));
+
+          print('Play');
+
+          await player.play();
+        }
+      });
+
+      await player.open(
+        Media(
+          'https://github.com/media-kit/media-kit/assets/28951144/efb4057c-6fd3-4644-a0b1-42d5fb420ce9',
+        ),
+      );
+
+      await Future.delayed(const Duration(minutes: 1));
+
+      await player.dispose();
+    },
+    timeout: Timeout(const Duration(minutes: 1, seconds: 30)),
   );
   test(
     'player-buffering-playlist',

--- a/media_kit_video/lib/src/video/video_texture.dart
+++ b/media_kit_video/lib/src/video/video_texture.dart
@@ -95,6 +95,12 @@ class Video extends StatefulWidget {
   /// Whether to pause the video when application enters background mode.
   final bool pauseUponEnteringBackgroundMode;
 
+  /// Whether to resume the video when application enters foreground mode.
+  ///
+  /// This attribute is only applicable if [pauseUponEnteringBackgroundMode] is `true`.
+  ///
+  final bool resumeUponEnteringForegroundMode;
+
   /// The configuration for subtitles e.g. [TextStyle] & padding etc.
   final SubtitleViewConfiguration subtitleViewConfiguration;
 
@@ -118,6 +124,7 @@ class Video extends StatefulWidget {
     this.controls = media_kit_video_controls.AdaptiveVideoControls,
     this.wakelock = true,
     this.pauseUponEnteringBackgroundMode = true,
+    this.resumeUponEnteringForegroundMode = false,
     this.subtitleViewConfiguration = const SubtitleViewConfiguration(),
     this.onEnterFullscreen = defaultEnterNativeFullscreen,
     this.onExitFullscreen = defaultExitNativeFullscreen,
@@ -132,6 +139,7 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
       GlobalKey<SubtitleViewState>();
   final Wakelock _wakelock = Wakelock();
   StreamSubscription? _playingSubscription;
+  bool _pauseDueToPauseUponEnteringBackgroundMode = false;
 
   // Public API:
 
@@ -169,7 +177,17 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
         AppLifecycleState.inactive,
         AppLifecycleState.detached,
       ].contains(state)) {
-        widget.controller.player.pause();
+        if (widget.controller.player.state.playing &&
+            !_pauseDueToPauseUponEnteringBackgroundMode) {
+          _pauseDueToPauseUponEnteringBackgroundMode = true;
+          widget.controller.player.pause();
+        }
+      } else {
+        if (widget.resumeUponEnteringForegroundMode &&
+            _pauseDueToPauseUponEnteringBackgroundMode) {
+          _pauseDueToPauseUponEnteringBackgroundMode = false;
+          widget.controller.player.play();
+        }
       }
     }
   }


### PR DESCRIPTION
- fix: `pause` during `buffering` makes `Player` not exit `buffering`
- fix: `error` stream
- test: player-buffering-pause-play
- feat: `Video` `resumeUponEnteringForegroundMode`