### PR TITLE
removed check on video player in find packages 

### DIFF
--- a/libs/android/media_kit_libs_android_audio/android/src/main/java/com/alexmercerind/media_kit_libs_android_audio/MediaKitLibsAndroidAudioPlugin.java
+++ b/libs/android/media_kit_libs_android_audio/android/src/main/java/com/alexmercerind/media_kit_libs_android_audio/MediaKitLibsAndroidAudioPlugin.java
@@ -98,12 +98,6 @@ public class MediaKitLibsAndroidAudioPlugin implements FlutterPlugin {
                             success = false;
                             break;
                         }
-                    } else if (name.contains("video") && name.contains("player")) {
-                        if (!name.contains("video_player") &&
-                            !name.contains("-")) {
-                            success = false;
-                            break;
-                        }
                     }
                 }
             }

--- a/libs/android/media_kit_libs_android_video/android/src/main/java/com/alexmercerind/media_kit_libs_android_video/MediaKitLibsAndroidVideoPlugin.java
+++ b/libs/android/media_kit_libs_android_video/android/src/main/java/com/alexmercerind/media_kit_libs_android_video/MediaKitLibsAndroidVideoPlugin.java
@@ -97,12 +97,6 @@ public class MediaKitLibsAndroidVideoPlugin implements FlutterPlugin {
                             success = false;
                             break;
                         }
-                    } else if (name.contains("video") && name.contains("player")) {
-                        if (!name.contains("video_player") &&
-                            !name.contains("-")) {
-                            success = false;
-                            break;
-                        }
                     }
                 }
             }

--- a/media_kit/lib/src/player/native/utils/find_packages.dart
+++ b/media_kit/lib/src/player/native/utils/find_packages.dart
@@ -74,11 +74,6 @@ abstract class FindPackages {
                 success = false;
                 break;
               }
-            } else if (name.contains('video') && name.contains('player')) {
-              if (!name.contains('video_player') && !name.contains('-')) {
-                success = false;
-                break;
-              }
             }
           }
         }


### PR DESCRIPTION
since i am doing what you requested in https://github.com/media-kit/media-kit/pull/382

the check is making my package flutter_meedu_videoplayer crash since its checking for videoplayer

even though its doesnt have media_kit in the name.

for the other packages with media_kit in its name i will change them to another names and disable the old ones. 