### PR TITLE
fix: reset `Player` state/stream upon `Player.open`; fix: hide last video's frame upon `Player.open`

### DIFF
--- a/media_kit/CHANGELOG.md
+++ b/media_kit/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.7
 
-fix: close `PlatformPlayer.playlistModeController`
+- fix: close `PlatformPlayer.playlistModeController`
 
 ## 1.1.6
 

--- a/media_kit/lib/src/player/platform_player.dart
+++ b/media_kit/lib/src/player/platform_player.dart
@@ -101,7 +101,7 @@ abstract class PlatformPlayer {
     );
     for (final callback in release) {
       try {
-        callback.call();
+        await callback.call();
       } catch (exception, stacktrace) {
         print(exception.toString());
         print(stacktrace.toString());
@@ -118,8 +118,6 @@ abstract class PlatformPlayer {
     );
   }
 
-  /// Stops the [Player].
-  /// Unloads the current [Media] or [Playlist] from the [Player]. This method is similar to [dispose] but does not release the resources & [Player] is still usable.
   Future<void> stop() {
     throw UnimplementedError(
       '[PlatformPlayer.stop] is not implemented',

--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -2261,6 +2261,8 @@ void main() {
         player.stream.buffering,
         emitsInOrder(
           [
+            // Player.open: buffering = false
+            false,
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2294,6 +2296,8 @@ void main() {
         player.stream.buffering,
         emitsInOrder(
           [
+            // Player.open: buffering = false
+            false,
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2326,6 +2330,8 @@ void main() {
         player.stream.buffering,
         emitsInOrder(
           [
+            // Player.open: buffering = false
+            false,
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2359,6 +2365,8 @@ void main() {
         player.stream.buffering,
         emitsInOrder(
           [
+            // Player.open: buffering = false
+            false,
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2390,6 +2398,8 @@ void main() {
         player.stream.buffering,
         emitsInOrder(
           [
+            // Player.open: buffering = false
+            false,
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2444,6 +2454,8 @@ void main() {
         player.stream.buffering,
         emitsInOrder(
           [
+            // Player.open: buffering = false
+            false,
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2516,6 +2528,9 @@ void main() {
         emitsInOrder(
           [
             // 0
+
+            // Player.open: buffering = false
+            false,
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2525,6 +2540,10 @@ void main() {
             false,
 
             // 1
+
+            // Player.open: buffering = false
+            // false,
+
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2534,6 +2553,10 @@ void main() {
             false,
 
             // 2
+
+            // Player.open: buffering = false
+            // false,
+
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2543,6 +2566,10 @@ void main() {
             false,
 
             // 3
+
+            // Player.open: buffering = false
+            // false,
+
             // Player.open: buffering = true
             true,
             // Player.open: buffering = false
@@ -2805,6 +2832,8 @@ void main() {
         player.stream.tracks,
         emitsInOrder(
           [
+            // Player.open
+            Tracks(),
             Tracks(
               video: [
                 VideoTrack('auto', null, null),
@@ -2830,6 +2859,7 @@ void main() {
                 SubtitleTrack('8', null, 'null'),
               ],
             ),
+            // EOF
             Tracks(),
             emitsDone,
           ],
@@ -2840,6 +2870,14 @@ void main() {
         player.stream.subtitle,
         emitsInOrder(
           [
+            TypeMatcher<List<String>>().having(
+              (subtitle) => ListEquality().equals(
+                subtitle,
+                ['', ''],
+              ),
+              '',
+              isTrue,
+            ),
             TypeMatcher<List<String>>().having(
               (subtitle) => ListEquality().equals(
                 subtitle,
@@ -2954,6 +2992,8 @@ void main() {
         player.stream.tracks,
         emitsInOrder(
           [
+            // Player.open
+            Tracks(),
             Tracks(
               video: [
                 VideoTrack('auto', null, null),
@@ -3005,6 +3045,7 @@ void main() {
                 SubtitleTrack('8', null, 'null'),
               ],
             ),
+            // EOF
             Tracks(),
             emitsDone,
           ],
@@ -3100,6 +3141,15 @@ void main() {
               'subtitle',
               isTrue,
             ),
+            // SAME VALUE!
+            // TypeMatcher<List<String>>().having(
+            //   (subtitle) => ListEquality().equals(
+            //     subtitle,
+            //     ['', ''],
+            //   ),
+            //   'subtitle',
+            //   isTrue,
+            // ),
             TypeMatcher<List<String>>().having(
               (subtitle) => ListEquality().equals(
                 subtitle,
@@ -3359,6 +3409,15 @@ Simply for <u>everyone</u>
               'subtitle',
               isTrue,
             ),
+            // SAME VALUE!
+            // TypeMatcher<List<String>>().having(
+            //   (subtitle) => ListEquality().equals(
+            //     subtitle,
+            //     ['', ''],
+            //   ),
+            //   'subtitle',
+            //   isTrue,
+            // ),
             TypeMatcher<List<String>>().having(
               (subtitle) => ListEquality().equals(
                 subtitle,

--- a/media_kit_video/lib/src/video/video_texture.dart
+++ b/media_kit_video/lib/src/video/video_texture.dart
@@ -137,8 +137,11 @@ class Video extends StatefulWidget {
 class VideoState extends State<Video> with WidgetsBindingObserver {
   final _contextNotifier = ValueNotifier<BuildContext?>(null);
   final _subtitleViewKey = GlobalKey<SubtitleViewState>();
-  final Wakelock _wakelock = Wakelock();
-  StreamSubscription? _playingSubscription;
+  final _wakelock = Wakelock();
+  final _subscriptions = <StreamSubscription>[];
+  late int? _width = widget.controller.player.state.width;
+  late int? _height = widget.controller.player.state.height;
+  late bool _visible = (_width ?? 0) > 0 && (_height ?? 0) > 0;
   bool _pauseDueToPauseUponEnteringBackgroundMode = false;
 
   // Public API:
@@ -194,18 +197,50 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    // --------------------------------------------------
+    // Do not show the video frame until width & height are available.
+    // Since [ValueNotifier<Rect?>] inside [VideoController] only gets updated by the render loop (i.e. it will not fire when video's width & height are not available etc.), it's important to handle this separately here.
+    _subscriptions.addAll(
+      [
+        widget.controller.player.stream.width.listen(
+          (value) {
+            _width = value;
+            final visible = (_width ?? 0) > 0 && (_height ?? 0) > 0;
+            if (_visible != visible) {
+              setState(() {
+                _visible = visible;
+              });
+            }
+          },
+        ),
+        widget.controller.player.stream.height.listen(
+          (value) {
+            _height = value;
+            final visible = (_width ?? 0) > 0 && (_height ?? 0) > 0;
+            if (_visible != visible) {
+              setState(() {
+                _visible = visible;
+              });
+            }
+          },
+        ),
+      ],
+    );
+    // --------------------------------------------------
     if (widget.wakelock) {
       if (widget.controller.player.state.playing) {
         _wakelock.enable();
       }
-      _playingSubscription = widget.controller.player.stream.playing.listen(
-        (playing) {
-          if (playing) {
-            _wakelock.enable();
-          } else {
-            _wakelock.disable();
-          }
-        },
+      _subscriptions.add(
+        widget.controller.player.stream.playing.listen(
+          (value) {
+            if (value) {
+              _wakelock.enable();
+            } else {
+              _wakelock.disable();
+            }
+          },
+        ),
       );
     }
   }
@@ -214,7 +249,9 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _wakelock.disable();
-    _playingSubscription?.cancel();
+    for (final subscription in _subscriptions) {
+      subscription.cancel();
+    }
     super.dispose();
   }
 
@@ -251,7 +288,7 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
                             return ValueListenableBuilder<Rect?>(
                               valueListenable: notifier.rect,
                               builder: (context, rect, _) {
-                                if (id != null && rect != null) {
+                                if (id != null && rect != null && _visible) {
                                   return SizedBox(
                                     // Apply aspect ratio if provided.
                                     width: aspectRatio == null


### PR DESCRIPTION
The behavior of `Player` is _mostly_ still the same.
Only 2 changes can be seen (which I believe are favorable) in tests, as it can be seen:
- `buffering` will be restored back to `false` once `Player.open` is called.
- `tracks` will be cleared once `Player.open` is called.

Primarily this is done to reset previously playing `Media`'s state (while newly opened buffering for example) e.g.
- [Last frame stuck.](https://github.com/media-kit/media-kit/issues/356#issuecomment-1675757193)
- [~~Last subtitles stuck.~~ A different fix & test will be needed.](https://github.com/media-kit/media-kit/issues/394#issuecomment-1694491967)

<hr>

I was already familiar with the issues & it'll be cool to have these resolved.
