### PR TITLE
fix: theme override

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -600,7 +600,7 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
   @override
   Widget build(BuildContext context) {
     return Theme(
-      data: ThemeData(
+      data: Theme.of(context).copyWith(
         focusColor: const Color(0x00000000),
         hoverColor: const Color(0x00000000),
         splashColor: const Color(0x00000000),

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -494,7 +494,7 @@ class _MaterialDesktopVideoControlsState
   @override
   Widget build(BuildContext context) {
     return Theme(
-      data: ThemeData(
+      data: Theme.of(context).copyWith(
         focusColor: const Color(0x00000000),
         hoverColor: const Color(0x00000000),
         splashColor: const Color(0x00000000),


### PR DESCRIPTION
any themes defined in the app is overridden in controls 

<img width="801" alt="image" src="https://github.com/media-kit/media-kit/assets/25157308/aa659f5f-c98e-482a-94ed-17f14d232ccc">

using the new changes the colors defined by media_kit are still the same but we dont override the user themes 
<img width="812" alt="image" src="https://github.com/media-kit/media-kit/assets/25157308/9769cb61-9a37-465a-aa0e-a64587a9f042">
