### PR TITLE
build(darwin): bump libs

### DIFF
--- a/libs/ios/media_kit_libs_ios_audio/ios/Makefile
+++ b/libs/ios/media_kit_libs_ios_audio/ios/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.5.3
-MPV_XCFRAMEWORKS_SHA256SUM=f0667958b23154d17d87e2efda4dfba885c33c0313ca1cff673c76582e87112e
+MPV_XCFRAMEWORKS_VERSION=v0.5.7
+MPV_XCFRAMEWORKS_SHA256SUM=8aef983d8ff254e85724249252d06eec17fac5936d0c742ec76fc42878b72cd4
 
 .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-ios-universal.tar.gz:
 	mkdir -p .cache/xcframeworks

--- a/libs/ios/media_kit_libs_ios_video/ios/Makefile
+++ b/libs/ios/media_kit_libs_ios_video/ios/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.5.3
-MPV_XCFRAMEWORKS_SHA256SUM=94fcc3bbb62a033d35d5c9b41d9e58089761fce07d95bfa9d9b83ac120913e86
+MPV_XCFRAMEWORKS_VERSION=v0.5.7
+MPV_XCFRAMEWORKS_SHA256SUM=75fa7ceca3950aa4823f783acb9f4defd4ffa590585fbb198988e5dfa765754b
 
 .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-ios-universal.tar.gz:
 	mkdir -p .cache/xcframeworks

--- a/libs/macos/media_kit_libs_macos_audio/macos/Makefile
+++ b/libs/macos/media_kit_libs_macos_audio/macos/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.5.3
-MPV_XCFRAMEWORKS_SHA256SUM=c061bfdf74812d15abdc01c6d38b8015a26311a8faf188fdf2e6b66aa5ae6c73
+MPV_XCFRAMEWORKS_VERSION=v0.5.7
+MPV_XCFRAMEWORKS_SHA256SUM=9c048c269ca8a38a88d93abdf28960b05767c8681cb1ac0da8c6ec396b7dbbad
 
 .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-macos-universal.tar.gz:
 	mkdir -p .cache/xcframeworks

--- a/libs/macos/media_kit_libs_macos_video/macos/Makefile
+++ b/libs/macos/media_kit_libs_macos_video/macos/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.5.3
-MPV_XCFRAMEWORKS_SHA256SUM=9408a77107290d8313a353788f25f3673d57affd1eaa240d10c014a52899c681
+MPV_XCFRAMEWORKS_VERSION=v0.5.7
+MPV_XCFRAMEWORKS_SHA256SUM=e887650b85fb5bc98f36cf2c615c969ea01ebbe63c2abf54789c46041d3acfaf
 
 .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-macos-universal.tar.gz:
 	mkdir -p .cache/xcframeworks


### PR DESCRIPTION
- fix iOS HDR (#372)
- ~~fix HLS MP4 seek (#395)~~
- fix VP9 macOS Intel freezes
- fix image based subtitles
- fix subtitles in m3u8 (#394)
- add AV1 support (#429)

---

As there are a lot of changes, particularly patches, there's a risk of introducing bugs, so I'm going to keep this PR open for a few days so that everyone can test it.