### PR TITLE
[Windows] Fix fullscreen for non-primary monitors

### DIFF
--- a/media_kit_video/windows/utils.cc
+++ b/media_kit_video/windows/utils.cc
@@ -38,8 +38,8 @@ void Utils::EnterNativeFullscreen(HWND window) {
                      &monitor);
     ::SetWindowLongPtr(window, GWL_STYLE, style & ~WS_OVERLAPPEDWINDOW);
     ::SetWindowPos(window, HWND_TOP, monitor.rcMonitor.left,
-                   monitor.rcMonitor.top, monitor.rcMonitor.right,
-                   monitor.rcMonitor.bottom,
+                   monitor.rcMonitor.top, monitor.rcMonitor.right - monitor.rcMonitor.left,
+                   monitor.rcMonitor.bottom - monitor.rcMonitor.top,
                    SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
   }
 }


### PR DESCRIPTION
Closes #439 

This change corrects the width and height parameters passed to the SetWindowPos function

Previously, the right and bottom coordinates of the monitor were incorrectly used as the window size. Now, the width and height are correctly calculated as the differences between the right and left coordinates and the bottom and top coordinates.