### PR TITLE
fix(darwin): fix memory leaks

### DIFF
--- a/media_kit_video/common/darwin/Classes/plugin/ResizableTextureProtocol.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/ResizableTextureProtocol.swift
@@ -7,5 +7,4 @@
 public protocol ResizableTextureProtocol: NSObject, FlutterTexture {
   func resize(_ size: CGSize)
   func render(_ size: CGSize)
-  func dispose()
 }

--- a/media_kit_video/common/darwin/Classes/plugin/SafeResizableTexture.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/SafeResizableTexture.swift
@@ -29,12 +29,6 @@ public class SafeResizableTexture:
     }
   }
 
-  public func dispose() {
-    return locked {
-      return child.dispose()
-    }
-  }
-
   public func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
     return child.copyPixelBuffer()
   }

--- a/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
@@ -29,6 +29,11 @@ public class TextureSW: NSObject, FlutterTexture, ResizableTextureProtocol {
     }
   }
 
+  deinit {
+    disposePixelBuffer()
+    disposeMPV()
+  }
+
   public func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
     let textureContext = textureContexts.current
     if textureContext == nil {
@@ -36,11 +41,6 @@ public class TextureSW: NSObject, FlutterTexture, ResizableTextureProtocol {
     }
 
     return Unmanaged.passRetained(textureContext!.pixelBuffer)
-  }
-
-  public func dispose() {
-    disposePixelBuffer()
-    disposeMPV()
   }
 
   private func initMPV() {

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -97,14 +97,26 @@ public class VideoOutput: NSObject {
       texture = SafeResizableTexture(
         TextureHW(
           handle: handle,
-          updateCallback: updateCallback
+          // Use `weak self` to prevent memory leaks
+          updateCallback: { [weak self]() in
+            guard let that = self else {
+              return
+            }
+            that.updateCallback()
+          }
         )
       )
     } else {
       texture = SafeResizableTexture(
         TextureSW(
           handle: handle,
-          updateCallback: updateCallback
+          // Use `weak self` to prevent memory leaks
+          updateCallback: { [weak self]() in
+            guard let that = self else {
+              return
+            }
+            that.updateCallback()
+          }
         )
       )
     }

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -59,18 +59,18 @@ public class VideoOutput: NSObject {
     }
   }
 
+  deinit {
+    worker.cancel()
+
+    disposed = true
+    disposeTextureId()
+  }
+
   public func setSize(width: Int64?, height: Int64?) {
     worker.enqueue {
       self.width = width
       self.height = height
     }
-  }
-
-  public func dispose() {
-    worker.cancel()
-
-    disposed = true
-    disposeTextureId()
   }
 
   private func _init() {

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -67,14 +67,9 @@ public class VideoOutput: NSObject {
   }
 
   public func dispose() {
-    worker.enqueue {
-      self._dispose()
-    }
-  }
+    worker.cancel()
 
-  private func _dispose() {
     disposed = true
-
     disposeTextureId()
   }
 

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -76,7 +76,6 @@ public class VideoOutput: NSObject {
     disposed = true
 
     disposeTextureId()
-    texture.dispose()
   }
 
   private func _init() {

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
@@ -51,7 +51,6 @@ public class VideoOutputManager: NSObject {
       return
     }
 
-    videoOutput!.dispose()
     self.videoOutputs[handle] = nil
   }
 }

--- a/media_kit_video/ios/Classes/plugin/TextureHW.swift
+++ b/media_kit_video/ios/Classes/plugin/TextureHW.swift
@@ -28,16 +28,7 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
     self.initMPV()
   }
 
-  public func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
-    let textureContext = textureContexts.current
-    if textureContext == nil {
-      return nil
-    }
-
-    return Unmanaged.passRetained(textureContext!.pixelBuffer)
-  }
-
-  public func dispose() {
+  deinit {
     disposePixelBuffer()
     disposeMPV()
     OpenGLESHelpers.deleteTextureCache(textureCache)
@@ -47,6 +38,15 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
     // Potential fix: use a counter, and delete it only when the counter reaches
     // zero
     OpenGLESHelpers.deleteContext(context)
+  }
+
+  public func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
+    let textureContext = textureContexts.current
+    if textureContext == nil {
+      return nil
+    }
+
+    return Unmanaged.passRetained(textureContext!.pixelBuffer)
   }
 
   private func initMPV() {

--- a/media_kit_video/ios/Classes/plugin/gles/OpenGLESHelpers.swift
+++ b/media_kit_video/ios/Classes/plugin/gles/OpenGLESHelpers.swift
@@ -138,6 +138,10 @@ public class OpenGLESHelpers {
     // automatically memory managed
   }
 
+  // BUG: `glDeleteTextures` does not release `CVOpenGLESTexture`.
+  // `CVOpenGLESTextureCache` retains a direct or indirect reference to
+  // `IOSurface`, which causes a memory leak until `CVOpenGLESTextureCache` is
+  // released.
   static public func deleteTexture(
     _ context: EAGLContext,
     _ texture: CVOpenGLESTexture

--- a/media_kit_video/macos/Classes/plugin/TextureHW.swift
+++ b/media_kit_video/macos/Classes/plugin/TextureHW.swift
@@ -31,16 +31,7 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
     self.initMPV()
   }
 
-  public func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
-    let textureContext = textureContexts.current
-    if textureContext == nil {
-      return nil
-    }
-
-    return Unmanaged.passRetained(textureContext!.pixelBuffer)
-  }
-
-  public func dispose() {
+  deinit {
     disposePixelBuffer()
     disposeMPV()
     OpenGLHelpers.deleteTextureCache(textureCache)
@@ -51,6 +42,15 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
     // Potential fix: use a counter, and delete it only when the counter reaches
     // zero
     OpenGLHelpers.deleteContext(context)
+  }
+
+  public func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
+    let textureContext = textureContexts.current
+    if textureContext == nil {
+      return nil
+    }
+
+    return Unmanaged.passRetained(textureContext!.pixelBuffer)
   }
 
   private func initMPV() {

--- a/media_kit_video/macos/Classes/plugin/gl/OpenGLHelpers.swift
+++ b/media_kit_video/macos/Classes/plugin/gl/OpenGLHelpers.swift
@@ -207,6 +207,10 @@ public class OpenGLHelpers {
     // automatically memory managed
   }
 
+  // BUG: `glDeleteTextures` does not release `CVOpenGLTexture`.
+  // `CVOpenGLTextureCache` retains a direct or indirect reference to
+  // `IOSurface`, which causes a memory leak until `CVOpenGLTextureCache` is
+  // released.
   static public func deleteTexture(
     _ context: CGLContextObj,
     _ texture: CVOpenGLTexture


### PR DESCRIPTION
Many classes don't `deinit` and keep references to sub classes who cannot `deinit` itself, etc…

When `VideoOutput` is destroyed, this prevents [ARC](https://en.wikipedia.org/wiki/Automatic_Reference_Counting) from releasing `CVOpenGL(ES)TextureCache`, who keeps direct / indirect references to `IOSurface` used by `CVPixelBuffer`.

Also, we discovered that `glDeleteTextures` doesn't release `CVOpenGL(ES)Texture`, `CVOpenGL(ES)TextureCache` must be released to delete references.

## About IOSurface "persistence" after Texture(HW/SW) release

After `Texture(HW/SW)` release, many `IOSurface` persist in memory. This is not a bug or a memory leak, but expected behavior.

With Xcode, we find that `IOSurface` are still referenced by `CVMetalTextureCache`, itself referenced by [FlutterDarwinContextMetalSkia](https://github.com/flutter/engine/blob/3.13.2/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.h#L72).

<img width="1366" alt="xcode_memory_screenshot" src="https://github.com/media-kit/media-kit/assets/32417752/880e23de-bfd6-450a-9d9a-b3a6bbcf74e3">

According to the documentation of [CVMetalTextureCacheFlush](https://developer.apple.com/documentation/corevideo/1457001-cvmetaltexturecacheflush):

> Texture caches automatically flush unused resources when you call the [CVMetalTextureCacheCreateTextureFromImage(_:_:_:_:_:_:_:_:_:)](https://developer.apple.com/documentation/corevideo/1456754-cvmetaltexturecachecreatetexture) function and on the time interval specified by [kCVMetalTextureCacheMaximumTextureAgeKey](https://developer.apple.com/documentation/corevideo/kcvmetaltexturecachemaximumtextureagekey). Use this method when you need fine-grained control over cache contents and memory.

This means that these `IOSurface` will be automatically released when a future `CVPixelBuffer` will be created.

---

Reported by @23doors