### PR TITLE
[Bug fix] Catch horizontalDragUpdate in MaterialSeekBar

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -1204,6 +1204,7 @@ class MaterialSeekBarState extends State<MaterialSeekBar> {
         builder: (context, constraints) => MouseRegion(
           cursor: SystemMouseCursors.click,
           child: GestureDetector(
+            onHorizontalDragUpdate: (_){},
             onPanStart: (e) => onPanStart(e, constraints),
             onPanDown: (e) => onPanDown(e, constraints),
             onPanUpdate: (e) => onPanUpdate(e, constraints),


### PR DESCRIPTION
`PageViews` and `ListViews` (and most probably many other scrollable widgets) use the `Scrollable` widget which uses `HorizontalDragGestureRecognizer`. If any of these two widgets are used as a parent to `MaterialSeekBar`, horizontal drag gestures are caught by `GestureDetectors` used in these widgets containing a `Scrollable` since we only catch `Pan` gestures in `MaterialSeekBar`.

#### Example

If one video is used for each page in a `PageView`, seeking the `MaterialSeekBar` leads to swiping and going to the next page because of this.

https://github.com/media-kit/media-kit/assets/77285023/a1963d1b-8b6a-4829-aa8c-7e21e47d6286

