### PR TITLE
fix: High gpu usage during idle

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -942,10 +942,18 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                             child: _theme(context)
                                     .bufferingIndicatorBuilder
                                     ?.call(context) ??
-                                const Center(
-                                  child: CircularProgressIndicator(
-                                    color: Color(0xFFFFFFFF),
-                                  ),
+                                TweenAnimationBuilder<double>(
+                                  tween: Tween<double>(begin: 0.4, end: 1.0),
+                                  duration: _theme(context)
+                                      .controlsTransitionDuration, // adjust as needed
+                                  builder: (BuildContext context, double value,
+                                      Widget? child) {
+                                    return Center(
+                                        child: CircularProgressIndicator(
+                                      value: buffering ? null : value,
+                                      color: const Color(0xFFFFFFFF),
+                                    ));
+                                  },
                                 ),
                           ),
                         ),

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -787,10 +787,20 @@ class _MaterialDesktopVideoControlsState
                                     child: _theme(context)
                                             .bufferingIndicatorBuilder
                                             ?.call(context) ??
-                                        const Center(
-                                          child: CircularProgressIndicator(
-                                            color: Color(0xFFFFFFFF),
-                                          ),
+                                        TweenAnimationBuilder<double>(
+                                          tween: Tween<double>(
+                                              begin: 0.4, end: 1.0),
+                                          duration: _theme(context)
+                                              .controlsTransitionDuration, // adjust as needed
+                                          builder: (BuildContext context,
+                                              double value, Widget? child) {
+                                            return Center(
+                                                child:
+                                                    CircularProgressIndicator(
+                                              value: buffering ? null : value,
+                                              color: const Color(0xFFFFFFFF),
+                                            ));
+                                          },
                                         ),
                                   ),
                                 ),


### PR DESCRIPTION
Sets the state of the controls CircularProgressIndicator to a constant value when we're not buffering.

Fixes #472 