### PR TITLE
feat(material-seekbar): Center the seek bar within its parent container for improved tap area

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -1260,54 +1260,56 @@ class MaterialSeekBarState extends State<MaterialSeekBar> {
                 color: Colors.transparent,
                 width: constraints.maxWidth,
                 height: _theme(context).seekBarContainerHeight,
-                child: Stack(
-                  clipBehavior: Clip.none,
-                  alignment: Alignment.bottomLeft,
-                  children: [
-                    Container(
-                      width: constraints.maxWidth,
-                      height: _theme(context).seekBarHeight,
-                      alignment: Alignment.bottomLeft,
-                      color: _theme(context).seekBarColor,
-                      child: Stack(
-                        clipBehavior: Clip.none,
+                child: Center(
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    alignment: Alignment.bottomLeft,
+                    children: [
+                      Container(
+                        width: constraints.maxWidth,
+                        height: _theme(context).seekBarHeight,
                         alignment: Alignment.bottomLeft,
-                        children: [
-                          Container(
-                            width: constraints.maxWidth * bufferPercent,
-                            color: _theme(context).seekBarBufferColor,
-                          ),
-                          Container(
-                            width: tapped
-                                ? constraints.maxWidth * slider
-                                : constraints.maxWidth * positionPercent,
-                            color: _theme(context).seekBarPositionColor,
-                          ),
-                        ],
+                        color: _theme(context).seekBarColor,
+                        child: Stack(
+                          clipBehavior: Clip.none,
+                          alignment: Alignment.bottomLeft,
+                          children: [
+                            Container(
+                              width: constraints.maxWidth * bufferPercent,
+                              color: _theme(context).seekBarBufferColor,
+                            ),
+                            Container(
+                              width: tapped
+                                  ? constraints.maxWidth * slider
+                                  : constraints.maxWidth * positionPercent,
+                              color: _theme(context).seekBarPositionColor,
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
-                    Positioned(
-                      left: tapped
-                          ? (constraints.maxWidth -
-                                  _theme(context).seekBarThumbSize / 2) *
-                              slider
-                          : (constraints.maxWidth -
-                                  _theme(context).seekBarThumbSize / 2) *
-                              positionPercent,
-                      bottom: -1.0 * _theme(context).seekBarThumbSize / 2 +
-                          _theme(context).seekBarHeight / 2,
-                      child: Container(
-                        width: _theme(context).seekBarThumbSize,
-                        height: _theme(context).seekBarThumbSize,
-                        decoration: BoxDecoration(
-                          color: _theme(context).seekBarThumbColor,
-                          borderRadius: BorderRadius.circular(
-                            _theme(context).seekBarThumbSize / 2,
+                      Positioned(
+                        left: tapped
+                            ? (constraints.maxWidth -
+                                    _theme(context).seekBarThumbSize / 2) *
+                                slider
+                            : (constraints.maxWidth -
+                                    _theme(context).seekBarThumbSize / 2) *
+                                positionPercent,
+                        bottom: -1.0 * _theme(context).seekBarThumbSize / 2 +
+                            _theme(context).seekBarHeight / 2,
+                        child: Container(
+                          width: _theme(context).seekBarThumbSize,
+                          height: _theme(context).seekBarThumbSize,
+                          decoration: BoxDecoration(
+                            color: _theme(context).seekBarThumbColor,
+                            borderRadius: BorderRadius.circular(
+                              _theme(context).seekBarThumbSize / 2,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
The green colour represents the seekbar's tap area. 
 
 #### Before
 The tap area is only on the top
![before](https://github.com/media-kit/media-kit/assets/77285023/28e5940c-1b87-4294-a031-ebef2b3b8f9a)

#### After
The tap area is even on both top and bottom
![after](https://github.com/media-kit/media-kit/assets/77285023/1a17849c-1db8-419d-9bc1-3721d293e7ea)
