### PR TITLE
v1.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@
 
 ```yaml
 dependencies:
-  media_kit: ^1.1.7                              # Primary package.
-  media_kit_video: ^1.1.8                        # For video rendering.
-  media_kit_libs_video: ^1.0.1                   # Native video dependencies.
+  media_kit: ^1.1.8                              # Primary package.
+  media_kit_video: ^1.1.9                        # For video rendering.
+  media_kit_libs_video: ^1.0.2                   # Native video dependencies.
 ```
 
 #### For apps that need audio playback:
 
 ```yaml
 dependencies:
-  media_kit: ^1.1.7                              # Primary package.  
-  media_kit_libs_audio: ^1.0.1                   # Native audio dependencies.
+  media_kit: ^1.1.8                              # Primary package.  
+  media_kit_libs_audio: ^1.0.2                   # Native audio dependencies.
 ```
 
 **Notes:**
@@ -70,11 +70,11 @@ dependencies:
 
 | Platform | Video | Audio | Notes | Demo |
 | -------- | ----- | ----- | ----- | ---- |
-| Android     | ✅    | ✅    | Android 5.0 or above.                | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_android-arm64-v8a.apk) |
-| iOS         | ✅    | ✅    | iOS 9 or above.                      | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_ios_arm64.7z)          |
-| macOS       | ✅    | ✅    | macOS 10.9 or above.                 | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_macos_universal.7z)    |
-| Windows     | ✅    | ✅    | Windows 7 or above.                  | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_win32_x64.7z)          |
-| GNU/Linux   | ✅    | ✅    | Any modern GNU/Linux distribution.   | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_linux_x64.7z)          |
+| Android     | ✅    | ✅    | Android 5.0 or above.                | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_android-arm64-v8a.apk) |
+| iOS         | ✅    | ✅    | iOS 9 or above.                      | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_ios_arm64.7z)          |
+| macOS       | ✅    | ✅    | macOS 10.9 or above.                 | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_macos_universal.7z)    |
+| Windows     | ✅    | ✅    | Windows 7 or above.                  | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_win32_x64.7z)          |
+| GNU/Linux   | ✅    | ✅    | Any modern GNU/Linux distribution.   | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_linux_x64.7z)          |
 | Web         | ✅    | ✅    | Any modern web browser.              | [Visit](https://media-kit.github.io/media-kit/)                                                                            |
 
 <table>

--- a/README.md
+++ b/README.md
@@ -1528,18 +1528,18 @@ Edit `android/app/src/main/AndroidManifest.xml` to add the following permissions
       -->
     <uses-permission android:name="android.permission.INTERNET" />
     <!--
-      Storage access permissions.
-      Android 12 or lower.
-      -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <!--
       Media access permissions.
       Android 13 or higher.
       https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions
       -->
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <!--
+      Storage access permissions.
+      Android 12 or lower.
+      -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>
 ```
 
@@ -1547,21 +1547,23 @@ Use [`package:permission_handler`](https://pub.dev/packages/permission_handler) 
 
 ```dart
 if (/* Android 13 or higher. */) {
-  if (await Permission.storage.isDenied || await Permission.storage.isPermanentlyDenied) {
-    final state = await Permission.storage.request();
+  // Video permissions.
+  if (await Permission.videos.isDenied || await Permission.videos.isPermanentlyDenied) {
+    final state = await Permission.videos.request();
     if (!state.isGranted) {
       await SystemNavigator.pop();
     }
   }
-} else {
+  // Audio permissions.
   if (await Permission.audio.isDenied || await Permission.audio.isPermanentlyDenied) {
     final state = await Permission.audio.request();
     if (!state.isGranted) {
       await SystemNavigator.pop();
     }
   }
-  if (await Permission.videos.isDenied || await Permission.videos.isPermanentlyDenied) {
-    final state = await Permission.videos.request();
+} else {
+  if (await Permission.storage.isDenied || await Permission.storage.isPermanentlyDenied) {
+    final state = await Permission.storage.request();
     if (!state.isGranted) {
       await SystemNavigator.pop();
     }

--- a/libs/android/media_kit_libs_android_audio/CHANGELOG.md
+++ b/libs/android/media_kit_libs_android_audio/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.4
+
+- build: bump dependencies
+- fix: DTS support
+
 ## 1.3.3
 
 - build: bump dependencies

--- a/libs/android/media_kit_libs_android_audio/android/build.gradle
+++ b/libs/android/media_kit_libs_android_audio/android/build.gradle
@@ -58,15 +58,15 @@ task downloadDependencies(type: Exec) {
     
     // Download all *.jar dependencies & verify their MD5 checksums.
 
-    def urlDefaultARM64 = "https://github.com/media-kit/libmpv-android-audio-build/releases/download/v1.1.3/default-arm64-v8a.jar"
-    def urlDefaultARMEABI = "https://github.com/media-kit/libmpv-android-audio-build/releases/download/v1.1.3/default-armeabi-v7a.jar"
-    def urlDefaultX86_64 = "https://github.com/media-kit/libmpv-android-audio-build/releases/download/v1.1.3/default-x86_64.jar"
-    def urlDefaultX86 = "https://github.com/media-kit/libmpv-android-audio-build/releases/download/v1.1.3/default-x86.jar"
+    def urlDefaultARM64 = "https://github.com/media-kit/libmpv-android-audio-build/releases/download/v1.1.4/default-arm64-v8a.jar"
+    def urlDefaultARMEABI = "https://github.com/media-kit/libmpv-android-audio-build/releases/download/v1.1.4/default-armeabi-v7a.jar"
+    def urlDefaultX86_64 = "https://github.com/media-kit/libmpv-android-audio-build/releases/download/v1.1.4/default-x86_64.jar"
+    def urlDefaultX86 = "https://github.com/media-kit/libmpv-android-audio-build/releases/download/v1.1.4/default-x86.jar"
 
-    def destDefaultARM64 = file("$buildDir/v1.1.3/default-arm64-v8a.jar")
-    def destDefaultARMEABI = file("$buildDir/v1.1.3/default-armeabi-v7a.jar")
-    def destDefaultX86_64 = file("$buildDir/v1.1.3/default-x86_64.jar")
-    def destDefaultX86 = file("$buildDir/v1.1.3/default-x86.jar")
+    def destDefaultARM64 = file("$buildDir/v1.1.4/default-arm64-v8a.jar")
+    def destDefaultARMEABI = file("$buildDir/v1.1.4/default-armeabi-v7a.jar")
+    def destDefaultX86_64 = file("$buildDir/v1.1.4/default-x86_64.jar")
+    def destDefaultX86 = file("$buildDir/v1.1.4/default-x86.jar")
 
     if (!destDefaultARM64.exists()) {
         destDefaultARM64.parentFile.mkdirs()
@@ -98,16 +98,16 @@ task downloadDependencies(type: Exec) {
     def md5DefaultX86_64 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destDefaultX86_64.toPath())).encodeHex().toString()
     def md5DefaultX86 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destDefaultX86.toPath())).encodeHex().toString()
 
-    if (md5DefaultARM64 != "a34a9dd3c78caeb7536de05600b1a23f") {
+    if (md5DefaultARM64 != "78a1a05fc812cd944c59d6cc23966634") {
         throw new GradleException("media_kit: arm64-v8a JAR verification failed.")
     }
-    if (md5DefaultARMEABI != "21584c9df210dc5d3006b4ca135c8277") {
+    if (md5DefaultARMEABI != "2ac4c22fe6652c8624462d4108c15f94") {
         throw new GradleException("media_kit: armeabi-v7a JAR verification failed.")
     }
-    if (md5DefaultX86_64 != "ea568e2763ec2296133562bd6440c16f") {
+    if (md5DefaultX86_64 != "6c0555c28c14d434c32ab8ddd8d11370") {
         throw new GradleException("media_kit: x86_64 JAR verification failed.")
     }
-    if (md5DefaultX86 != "4dfaeadd63b370d04995eb5157b2aae0") {
+    if (md5DefaultX86 != "d8323463ed636734d7e576e0a1fcbd01") {
         throw new GradleException("media_kit: x86 JAR verification failed.")
     }
 

--- a/libs/android/media_kit_libs_android_audio/example/README.md
+++ b/libs/android/media_kit_libs_android_audio/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_android_audio: ^1.3.3
+  media_kit_libs_android_audio: ^1.3.4
 ```
 
 This will automatically bundle required shared libraries for audio (only) playback on Android.

--- a/libs/android/media_kit_libs_android_audio/pubspec.yaml
+++ b/libs/android/media_kit_libs_android_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_android_audio
 description: Android package providing audio (only) native libraries for package:media_kit.
-version: 1.3.3
+version: 1.3.4
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/android/media_kit_libs_android_video/CHANGELOG.md
+++ b/libs/android/media_kit_libs_android_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.4
+
+- build: bump dependencies
+- fix: DTS support
+
 ## 1.3.3
 
 - build: bump dependencies

--- a/libs/android/media_kit_libs_android_video/android/build.gradle
+++ b/libs/android/media_kit_libs_android_video/android/build.gradle
@@ -58,15 +58,15 @@ task downloadDependencies(type: Exec) {
     
     // Download all *.jar dependencies & verify their MD5 checksums.
 
-    def urlDefaultARM64 = "https://github.com/media-kit/libmpv-android-video-build/releases/download/v1.1.3/default-arm64-v8a.jar"
-    def urlDefaultARMEABI = "https://github.com/media-kit/libmpv-android-video-build/releases/download/v1.1.3/default-armeabi-v7a.jar"
-    def urlDefaultX86_64 = "https://github.com/media-kit/libmpv-android-video-build/releases/download/v1.1.3/default-x86_64.jar"
-    def urlDefaultX86 = "https://github.com/media-kit/libmpv-android-video-build/releases/download/v1.1.3/default-x86.jar"
+    def urlDefaultARM64 = "https://github.com/media-kit/libmpv-android-video-build/releases/download/v1.1.4/default-arm64-v8a.jar"
+    def urlDefaultARMEABI = "https://github.com/media-kit/libmpv-android-video-build/releases/download/v1.1.4/default-armeabi-v7a.jar"
+    def urlDefaultX86_64 = "https://github.com/media-kit/libmpv-android-video-build/releases/download/v1.1.4/default-x86_64.jar"
+    def urlDefaultX86 = "https://github.com/media-kit/libmpv-android-video-build/releases/download/v1.1.4/default-x86.jar"
 
-    def destDefaultARM64 = file("$buildDir/v1.1.3/default-arm64-v8a.jar")
-    def destDefaultARMEABI = file("$buildDir/v1.1.3/default-armeabi-v7a.jar")
-    def destDefaultX86_64 = file("$buildDir/v1.1.3/default-x86_64.jar")
-    def destDefaultX86 = file("$buildDir/v1.1.3/default-x86.jar")
+    def destDefaultARM64 = file("$buildDir/v1.1.4/default-arm64-v8a.jar")
+    def destDefaultARMEABI = file("$buildDir/v1.1.4/default-armeabi-v7a.jar")
+    def destDefaultX86_64 = file("$buildDir/v1.1.4/default-x86_64.jar")
+    def destDefaultX86 = file("$buildDir/v1.1.4/default-x86.jar")
 
     if (!destDefaultARM64.exists()) {
         destDefaultARM64.parentFile.mkdirs()
@@ -98,16 +98,16 @@ task downloadDependencies(type: Exec) {
     def md5DefaultX86_64 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destDefaultX86_64.toPath())).encodeHex().toString()
     def md5DefaultX86 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destDefaultX86.toPath())).encodeHex().toString()
 
-    if (md5DefaultARM64 != "b2ba098ee9632ba7241e9ede89f17af3") {
+    if (md5DefaultARM64 != "f91527316d2bbababadff81fc7f90580") {
         throw new GradleException("media_kit: arm64-v8a JAR verification failed.")
     }
-    if (md5DefaultARMEABI != "4f1e51e9e14928f8abd8964cc10b5142") {
+    if (md5DefaultARMEABI != "aa634169aa2323b2ae02ac570594db89") {
         throw new GradleException("media_kit: armeabi-v7a JAR verification failed.")
     }
-    if (md5DefaultX86_64 != "0a58c0ee5890b6d0aff5438f5d7a34aa") {
+    if (md5DefaultX86_64 != "cc9ebfd2b57eb28f4971b42d5d689f77") {
         throw new GradleException("media_kit: x86_64 JAR verification failed.")
     }
-    if (md5DefaultX86 != "b1e9e34c00cc324004d65ee5b71e24e3") {
+    if (md5DefaultX86 != "d0d9caaa4240a41ccd7e2f6e30079b2b") {
         throw new GradleException("media_kit: x86 JAR verification failed.")
     }
 

--- a/libs/android/media_kit_libs_android_video/example/README.md
+++ b/libs/android/media_kit_libs_android_video/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_android_video: ^1.3.3
+  media_kit_libs_android_video: ^1.3.4
 ```
 
 This will automatically bundle required shared libraries for video (& audio) playback on Android.

--- a/libs/android/media_kit_libs_android_video/pubspec.yaml
+++ b/libs/android/media_kit_libs_android_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_android_video
 description: Android package providing video (& audio) native libraries for package:media_kit.
-version: 1.3.3
+version: 1.3.4
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/ios/media_kit_libs_ios_audio/CHANGELOG.md
+++ b/libs/ios/media_kit_libs_ios_audio/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.4
+
+- fix: DTS support ([#437](https://github.com/media-kit/media-kit/issues/437))
+- perf: replace [LibreSSL](https://www.libressl.org/) w/ [Mbed TLS](https://github.com/Mbed-TLS/mbedtls)
+- perf: fix and enable assembly optimizations
+
 ## 1.1.3
 
 - fix: DASH having BaseURL(s) with special characters not loading ([#353](https://github.com/media-kit/media-kit/issues/353))

--- a/libs/ios/media_kit_libs_ios_audio/example/README.md
+++ b/libs/ios/media_kit_libs_ios_audio/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_ios_audio: ^1.1.3
+  media_kit_libs_ios_audio: ^1.1.4
 ```
 
 This will automatically bundle required shared libraries for audio playback on iOS.

--- a/libs/ios/media_kit_libs_ios_audio/ios/Makefile
+++ b/libs/ios/media_kit_libs_ios_audio/ios/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.5.8
-MPV_XCFRAMEWORKS_SHA256SUM=2fbaa5e21ee3af624f4e51c14252508152d703c5efc717046237b133f49bb089
+MPV_XCFRAMEWORKS_VERSION=v0.6.0
+MPV_XCFRAMEWORKS_SHA256SUM=8b8de92dc5482b8950c18bce6b8fa90204fd15af18f371acc9f5be07a4234e49
 
 .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-ios-universal.tar.gz:
 	mkdir -p .cache/xcframeworks

--- a/libs/ios/media_kit_libs_ios_audio/pubspec.yaml
+++ b/libs/ios/media_kit_libs_ios_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_ios_audio
 description: iOS package providing audio native libraries for package:media_kit.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/ios/media_kit_libs_ios_video/CHANGELOG.md
+++ b/libs/ios/media_kit_libs_ios_video/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.4
+
+- feat: AV1 support ([#429](https://github.com/media-kit/media-kit/issues/429))
+- fix: DTS support ([#437](https://github.com/media-kit/media-kit/issues/437))
+- fix: movtext subtitle support ([#394](https://github.com/media-kit/media-kit/issues/394))
+- fix: image based subtitles
+- fix: HDR support ([#372](https://github.com/media-kit/media-kit/issues/372))
+- perf: replace [LibreSSL](https://www.libressl.org/) w/ [Mbed TLS](https://github.com/Mbed-TLS/mbedtls)
+- perf: fix and enable assembly optimizations
+
 ## 1.1.3
 
 - fix: DASH having BaseURL(s) with special characters not loading ([#353](https://github.com/media-kit/media-kit/issues/353))

--- a/libs/ios/media_kit_libs_ios_video/example/README.md
+++ b/libs/ios/media_kit_libs_ios_video/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_ios_video: ^1.1.3
+  media_kit_libs_ios_video: ^1.1.4
 ```
 
 This will automatically bundle required shared libraries for video (& audio) playback on iOS.

--- a/libs/ios/media_kit_libs_ios_video/ios/Makefile
+++ b/libs/ios/media_kit_libs_ios_video/ios/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.5.8
-MPV_XCFRAMEWORKS_SHA256SUM=1dcf5eb727689f01844c8b9dc0e7dd414397aa8cfd72120038defa244afeaad1
+MPV_XCFRAMEWORKS_VERSION=v0.6.0
+MPV_XCFRAMEWORKS_SHA256SUM=a95bc18508af26136b8a408341c05b5585d644ec013f00ac07db09d2e28d36ae
 
 .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-ios-universal.tar.gz:
 	mkdir -p .cache/xcframeworks

--- a/libs/ios/media_kit_libs_ios_video/pubspec.yaml
+++ b/libs/ios/media_kit_libs_ios_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_ios_video
 description: iOS package providing video (& audio) native libraries for package:media_kit.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/linux/media_kit_libs_linux/CHANGELOG.md
+++ b/libs/linux/media_kit_libs_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+- feat: improve compile-time failure handling
+
 ## 1.1.2
 
 - build: bump libraries

--- a/libs/linux/media_kit_libs_linux/example/README.md
+++ b/libs/linux/media_kit_libs_linux/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_linux: ^1.1.2
+  media_kit_libs_linux: ^1.1.3
 ```
 
 This will automatically invoke the necessary initialization code.

--- a/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
+++ b/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
@@ -17,36 +17,35 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 #
 # Refer to "Static Override" section in mimalloc's documentation:
 # https://github.com/microsoft/mimalloc#static-override
-
-
 function(download_and_verify url md5 locationForArchive)
-    # Check if the archive exists.
-    if(EXISTS "${locationForArchive}")
-        file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+  # Check if the archive exists.
+  if(EXISTS "${locationForArchive}")
+    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
 
-        # If MD5 doesn't match, delete the archive to download again.
-        if(NOT md5 STREQUAL ARCHIVE_MD5)
-            file(REMOVE "${locationForArchive}")
-            message(STATUS "MD5 mismatch. File deleted.")
-        endif()
+    # If MD5 doesn't match, delete the archive to download again.
+    if(NOT md5 STREQUAL ARCHIVE_MD5)
+      file(REMOVE "${locationForArchive}")
+      message(STATUS "MD5 mismatch. File deleted.")
     endif()
+  endif()
 
-    # Download the archive if it doesn't exist.
-    if(NOT EXISTS "${locationForArchive}")
-        message(STATUS "Downloading archive from ${url}...")
-        file(DOWNLOAD "${url}" "${locationForArchive}")
-        message(STATUS "Downloaded archive to ${locationForArchive}.")
+  # Download the archive if it doesn't exist.
+  if(NOT EXISTS "${locationForArchive}")
+    message(STATUS "Downloading archive from ${url}...")
+    file(DOWNLOAD "${url}" "${locationForArchive}")
+    message(STATUS "Downloaded archive to ${locationForArchive}.")
 
-        # Verify MD5 of the newly downloaded file.
-        file(MD5 "${locationForArchive}" ARCHIVE_MD5)
-        if(md5 STREQUAL ARCHIVE_MD5)
-            message(STATUS "${locationForArchive} Verification successful.")
-        else()
-            message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to rebuild project again.")
-        endif()
+    # Verify MD5 of the newly downloaded file.
+    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+
+    if(md5 STREQUAL ARCHIVE_MD5)
+      message(STATUS "${locationForArchive} Verification successful.")
+    else()
+      message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to rebuild project again.")
     endif()
-
+  endif()
 endfunction()
+
 # ------------------------------------------------------------------------------
 set(MIMALLOC "mimalloc-2.1.2.tar.gz")
 
@@ -63,20 +62,21 @@ download_and_verify(
 )
 
 function(check_directory_exists_and_not_empty dir result_var)
-    # Check if the directory exists
-    if(EXISTS "${dir}")
-        # Check if the directory is not empty
-        file(GLOB dir_contents "${dir}/*")
-        if(dir_contents)
-            set(${result_var} TRUE PARENT_SCOPE)
-        else()
-            set(${result_var} FALSE PARENT_SCOPE)
-            message(STATUS "Directory ${dir} exists but is empty!")
-        endif()
+  # Check if the directory exists
+  if(EXISTS "${dir}")
+    # Check if the directory is not empty
+    file(GLOB dir_contents "${dir}/*")
+
+    if(dir_contents)
+      set(${result_var} TRUE PARENT_SCOPE)
     else()
-        set(${result_var} FALSE PARENT_SCOPE)
-        message(STATUS "Directory ${dir} does not exist!")
+      set(${result_var} FALSE PARENT_SCOPE)
+      message(STATUS "Directory ${dir} exists but is empty!")
     endif()
+  else()
+    set(${result_var} FALSE PARENT_SCOPE)
+    message(STATUS "Directory ${dir} does not exist!")
+  endif()
 endfunction()
 
 # Extract

--- a/libs/linux/media_kit_libs_linux/pubspec.yaml
+++ b/libs/linux/media_kit_libs_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_linux
 description: GNU/Linux dependency package for package:media_kit. Necessary for initialization.
-version: 1.1.2
+version: 1.1.3
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/macos/media_kit_libs_macos_audio/CHANGELOG.md
+++ b/libs/macos/media_kit_libs_macos_audio/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.4
+
+- fix: DTS support ([#437](https://github.com/media-kit/media-kit/issues/437))
+- perf: replace [LibreSSL](https://www.libressl.org/) w/ [Mbed TLS](https://github.com/Mbed-TLS/mbedtls)
+- perf: fix and enable assembly optimizations
+
 ## 1.1.3
 
 - fix: DASH having BaseURL(s) with special characters not loading ([#353](https://github.com/media-kit/media-kit/issues/353))

--- a/libs/macos/media_kit_libs_macos_audio/example/README.md
+++ b/libs/macos/media_kit_libs_macos_audio/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_macos_audio: ^1.1.3
+  media_kit_libs_macos_audio: ^1.1.4
 ```
 
 This will automatically bundle required shared libraries for audio playback on macOS.

--- a/libs/macos/media_kit_libs_macos_audio/macos/Makefile
+++ b/libs/macos/media_kit_libs_macos_audio/macos/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.5.8
-MPV_XCFRAMEWORKS_SHA256SUM=87e3c46ec05bc72cb39c6b920942857c8e0bcccba27c88619f118ec4f66a7168
+MPV_XCFRAMEWORKS_VERSION=v0.6.0
+MPV_XCFRAMEWORKS_SHA256SUM=916220b7b4fe9209de41264382966ac90a2de2ac11956a4b6041cf66a8110732
 
 .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-macos-universal.tar.gz:
 	mkdir -p .cache/xcframeworks

--- a/libs/macos/media_kit_libs_macos_audio/pubspec.yaml
+++ b/libs/macos/media_kit_libs_macos_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_macos_audio
 description: macOS package providing audio native libraries for package:media_kit.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/macos/media_kit_libs_macos_video/CHANGELOG.md
+++ b/libs/macos/media_kit_libs_macos_video/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.4
+
+- feat: AV1 support ([#429](https://github.com/media-kit/media-kit/issues/429))
+- fix: DTS support ([#437](https://github.com/media-kit/media-kit/issues/437))
+- fix: movtext subtitle support ([#394](https://github.com/media-kit/media-kit/issues/394))
+- fix: image based subtitles
+- fix: VP9 macOS Intel freeze
+- perf: replace [LibreSSL](https://www.libressl.org/) w/ [Mbed TLS](https://github.com/Mbed-TLS/mbedtls)
+- perf: fix and enable assembly optimizations
+
 ## 1.1.3
 
 - fix: DASH having BaseURL(s) with special characters not loading ([#353](https://github.com/media-kit/media-kit/issues/353))

--- a/libs/macos/media_kit_libs_macos_video/example/README.md
+++ b/libs/macos/media_kit_libs_macos_video/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_macos_video: ^1.1.3
+  media_kit_libs_macos_video: ^1.1.4
 ```
 
 This will automatically bundle required shared libraries for video (& audio) playback on macOS.

--- a/libs/macos/media_kit_libs_macos_video/macos/Makefile
+++ b/libs/macos/media_kit_libs_macos_video/macos/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.5.8
-MPV_XCFRAMEWORKS_SHA256SUM=726017f122efa70396fdef12f0d341e36ced205467288e017200f16b976a2e97
+MPV_XCFRAMEWORKS_VERSION=v0.6.0
+MPV_XCFRAMEWORKS_SHA256SUM=84d2ad98e046e82c6dc34d8547d76c2afeaee89c0f53032773be8985c95536d6
 
 .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-macos-universal.tar.gz:
 	mkdir -p .cache/xcframeworks

--- a/libs/macos/media_kit_libs_macos_video/pubspec.yaml
+++ b/libs/macos/media_kit_libs_macos_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_macos_video
 description: macOS package providing video (& audio) native libraries for package:media_kit.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/universal/media_kit_libs_audio/CHANGELOG.md
+++ b/libs/universal/media_kit_libs_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- build: bump dependencies
+
 ## 1.0.1
 
 - chore: declare `flutter` as `environment` in `pubspec.yaml`

--- a/libs/universal/media_kit_libs_audio/example/README.md
+++ b/libs/universal/media_kit_libs_audio/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_audio: ^1.0.1
+  media_kit_libs_audio: ^1.0.2
 ```
 
 This will automatically invoke the necessary initialization code.

--- a/libs/universal/media_kit_libs_audio/pubspec.yaml
+++ b/libs/universal/media_kit_libs_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_audio
 description: package:media_kit audio (only) playback native libraries for all platforms.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 
@@ -9,9 +9,9 @@ environment:
   flutter: ">=3.7.0"
 
 dependencies:
-  media_kit_native_event_loop: ^1.0.7
-  media_kit_libs_android_audio: ^1.3.3
-  media_kit_libs_ios_audio: ^1.1.3
-  media_kit_libs_macos_audio: ^1.1.3
-  media_kit_libs_windows_audio: ^1.0.8
-  media_kit_libs_linux: ^1.1.2
+  media_kit_native_event_loop: ^1.0.8
+  media_kit_libs_android_audio: ^1.3.4
+  media_kit_libs_ios_audio: ^1.1.4
+  media_kit_libs_macos_audio: ^1.1.4
+  media_kit_libs_windows_audio: ^1.0.9
+  media_kit_libs_linux: ^1.1.3

--- a/libs/universal/media_kit_libs_video/CHANGELOG.md
+++ b/libs/universal/media_kit_libs_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- build: bump dependencies
+
 ## 1.0.1
 
 - chore: declare `flutter` as `environment` in `pubspec.yaml`

--- a/libs/universal/media_kit_libs_video/example/README.md
+++ b/libs/universal/media_kit_libs_video/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_video: ^1.0.1
+  media_kit_libs_video: ^1.0.2
 ```
 
 This will automatically invoke the necessary initialization code.

--- a/libs/universal/media_kit_libs_video/pubspec.yaml
+++ b/libs/universal/media_kit_libs_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_video
 description: package:media_kit video (& audio) playback native libraries for all platforms.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 
@@ -9,9 +9,9 @@ environment:
   flutter: ">=3.7.0"
 
 dependencies:
-  media_kit_native_event_loop: ^1.0.7
-  media_kit_libs_android_video: ^1.3.3
-  media_kit_libs_ios_video: ^1.1.3
-  media_kit_libs_macos_video: ^1.1.3
-  media_kit_libs_windows_video: ^1.0.8
-  media_kit_libs_linux: ^1.1.2
+  media_kit_native_event_loop: ^1.0.8
+  media_kit_libs_android_video: ^1.3.4
+  media_kit_libs_ios_video: ^1.1.4
+  media_kit_libs_macos_video: ^1.1.4
+  media_kit_libs_windows_video: ^1.0.9
+  media_kit_libs_linux: ^1.1.3

--- a/libs/windows/media_kit_libs_windows_audio/CHANGELOG.md
+++ b/libs/windows/media_kit_libs_windows_audio/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.9
+
+- [mpv-player/mpv@`652a1dd`](https://github.com/mpv-player/mpv/commit/652a1dd90711839acdccc08004056d25514ef2d8)
+- feat: improve compile-time failure handling
+
 ## 1.0.8
 
 - [mpv-player/mpv@`ce79976`](https://github.com/mpv-player/mpv/commit/ce7997649816e4d6c05071fbd4ecac0557120720)

--- a/libs/windows/media_kit_libs_windows_audio/example/README.md
+++ b/libs/windows/media_kit_libs_windows_audio/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_windows_audio: ^1.0.8
+  media_kit_libs_windows_audio: ^1.0.9
 ```
 
 This will automatically bundle required shared libraries for audio (only) playback on Windows.

--- a/libs/windows/media_kit_libs_windows_audio/pubspec.yaml
+++ b/libs/windows/media_kit_libs_windows_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_windows_audio
 description: Windows package providing audio (only) native libraries for package:media_kit.
-version: 1.0.8
+version: 1.0.9
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/windows/media_kit_libs_windows_audio/windows/CMakeLists.txt
+++ b/libs/windows/media_kit_libs_windows_audio/windows/CMakeLists.txt
@@ -14,59 +14,60 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 
 # ------------------------------------------------------------------------------
 function(download_and_verify url md5 locationForArchive)
-    # Check if the archive exists.
-    if(EXISTS "${locationForArchive}")
-        file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+  # Check if the archive exists.
+  if(EXISTS "${locationForArchive}")
+    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
 
-        # If MD5 doesn't match, delete the archive to download again.
-        if(NOT md5 STREQUAL ARCHIVE_MD5)
-            file(REMOVE "${locationForArchive}")
-            message(STATUS "MD5 mismatch. File deleted.")
-        endif()
+    # If MD5 doesn't match, delete the archive to download again.
+    if(NOT md5 STREQUAL ARCHIVE_MD5)
+      file(REMOVE "${locationForArchive}")
+      message(STATUS "MD5 mismatch. File deleted.")
     endif()
+  endif()
 
-    # Download the archive if it doesn't exist.
-    if(NOT EXISTS "${locationForArchive}")
-        message(STATUS "Downloading archive from ${url}...")
-        file(DOWNLOAD "${url}" "${locationForArchive}")
-        message(STATUS "Downloaded archive to ${locationForArchive}.")
+  # Download the archive if it doesn't exist.
+  if(NOT EXISTS "${locationForArchive}")
+    message(STATUS "Downloading archive from ${url}...")
+    file(DOWNLOAD "${url}" "${locationForArchive}")
+    message(STATUS "Downloaded archive to ${locationForArchive}.")
 
-        # Verify MD5 of the newly downloaded file.
-        file(MD5 "${locationForArchive}" ARCHIVE_MD5)
-        if(md5 STREQUAL ARCHIVE_MD5)
-            message(STATUS "${locationForArchive} Verification successful.")
-        else()
-            message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to rebuild project again.")
-        endif()
+    # Verify MD5 of the newly downloaded file.
+    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+
+    if(md5 STREQUAL ARCHIVE_MD5)
+      message(STATUS "${locationForArchive} Verification successful.")
+    else()
+      message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to re-build project again.")
     endif()
-
+  endif()
 endfunction()
 
 function(check_directory_exists_and_not_empty dir result_var)
-    # Check if the directory exists
-    if(EXISTS "${dir}")
-        # Check if the directory is not empty
-        file(GLOB dir_contents "${dir}/*")
-        if(dir_contents)
-            set(${result_var} TRUE PARENT_SCOPE)
-        else()
-            set(${result_var} FALSE PARENT_SCOPE)
-            message(STATUS "Directory ${dir} exists but is empty!")
-        endif()
+  # Check if the directory exists
+  if(EXISTS "${dir}")
+    # Check if the directory is not empty
+    file(GLOB dir_contents "${dir}/*")
+
+    if(dir_contents)
+      set(${result_var} TRUE PARENT_SCOPE)
     else()
-        set(${result_var} FALSE PARENT_SCOPE)
-        message(STATUS "Directory ${dir} does not exist!")
+      set(${result_var} FALSE PARENT_SCOPE)
+      message(STATUS "Directory ${dir} exists but is empty!")
     endif()
+  else()
+    set(${result_var} FALSE PARENT_SCOPE)
+    message(STATUS "Directory ${dir} does not exist!")
+  endif()
 endfunction()
 
 # Thanks to Mitchel Stewart (https://github.com/Quackdoc) for providing patches to generate minimal libmpv & FFmpeg audio specific builds.
 
 # libmpv archive containing the pre-built shared libraries & headers.
-set(LIBMPV "mpv-dev-x86_64-20230824-git-ce79976.7z")
+set(LIBMPV "mpv-dev-x86_64-20230924-git-652a1dd.7z")
 
 # Download URL & MD5 hash of the libmpv archive.
-set(LIBMPV_URL "https://github.com/media-kit/libmpv-win32-audio-build/releases/download/2023-08-24/${LIBMPV}")
-set(LIBMPV_MD5 "fbe60253954772dde967f52723198523")
+set(LIBMPV_URL "https://github.com/media-kit/libmpv-win32-audio-build/releases/download/2023-09-24/${LIBMPV}")
+set(LIBMPV_MD5 "cd738e16e2a19626d7cfa48801524f8c")
 
 # Download location of the libmpv archive.
 set(LIBMPV_ARCHIVE "${CMAKE_BINARY_DIR}/${LIBMPV}")

--- a/libs/windows/media_kit_libs_windows_video/CHANGELOG.md
+++ b/libs/windows/media_kit_libs_windows_video/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.9
+
+- [mpv-player/mpv@`652a1dd`](https://github.com/mpv-player/mpv/commit/652a1dd90711839acdccc08004056d25514ef2d8)
+- [ANGLE 2.1.18844 git hash: 2693b03eba82](https://github.com/google/angle)
+- MSVCRT
+- UCRT
+- feat: improve compile-time failure handling
+
 ## 1.0.8
 
 - [mpv-player/mpv@`c0fb9b4`](https://github.com/mpv-player/mpv/commit/c0fb9b4b83905ff29f2b4c678af431561b5b53be)

--- a/libs/windows/media_kit_libs_windows_video/example/README.md
+++ b/libs/windows/media_kit_libs_windows_video/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_windows_audio: ^1.0.8
+  media_kit_libs_windows_audio: ^1.0.9
 ```
 
 This will automatically bundle required shared libraries for video (& audio) playback on Windows.

--- a/libs/windows/media_kit_libs_windows_video/pubspec.yaml
+++ b/libs/windows/media_kit_libs_windows_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_windows_video
 description: Windows package providing video (& audio) native libraries for package:media_kit.
-version: 1.0.8
+version: 1.0.9
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
+++ b/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
@@ -14,57 +14,58 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 
 # ------------------------------------------------------------------------------
 function(download_and_verify url md5 locationForArchive)
-    # Check if the archive exists.
-    if(EXISTS "${locationForArchive}")
-        file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+  # Check if the archive exists.
+  if(EXISTS "${locationForArchive}")
+    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
 
-        # If MD5 doesn't match, delete the archive to download again.
-        if(NOT md5 STREQUAL ARCHIVE_MD5)
-            file(REMOVE "${locationForArchive}")
-            message(STATUS "MD5 mismatch. File deleted.")
-        endif()
+    # If MD5 doesn't match, delete the archive to download again.
+    if(NOT md5 STREQUAL ARCHIVE_MD5)
+      file(REMOVE "${locationForArchive}")
+      message(STATUS "MD5 mismatch. File deleted.")
     endif()
+  endif()
 
-    # Download the archive if it doesn't exist.
-    if(NOT EXISTS "${locationForArchive}")
-        message(STATUS "Downloading archive from ${url}...")
-        file(DOWNLOAD "${url}" "${locationForArchive}")
-        message(STATUS "Downloaded archive to ${locationForArchive}.")
+  # Download the archive if it doesn't exist.
+  if(NOT EXISTS "${locationForArchive}")
+    message(STATUS "Downloading archive from ${url}...")
+    file(DOWNLOAD "${url}" "${locationForArchive}")
+    message(STATUS "Downloaded archive to ${locationForArchive}.")
 
-        # Verify MD5 of the newly downloaded file.
-        file(MD5 "${locationForArchive}" ARCHIVE_MD5)
-        if(md5 STREQUAL ARCHIVE_MD5)
-            message(STATUS "${locationForArchive} Verification successful.")
-        else()
-            message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to rebuild project again.")
-        endif()
+    # Verify MD5 of the newly downloaded file.
+    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+
+    if(md5 STREQUAL ARCHIVE_MD5)
+      message(STATUS "${locationForArchive} Verification successful.")
+    else()
+      message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to re-build project again.")
     endif()
-
+  endif()
 endfunction()
 
 function(check_directory_exists_and_not_empty dir result_var)
-    # Check if the directory exists
-    if(EXISTS "${dir}")
-        # Check if the directory is not empty
-        file(GLOB dir_contents "${dir}/*")
-        if(dir_contents)
-            set(${result_var} TRUE PARENT_SCOPE)
-        else()
-            set(${result_var} FALSE PARENT_SCOPE)
-            message(STATUS "Directory ${dir} exists but is empty!")
-        endif()
+  # Check if the directory exists
+  if(EXISTS "${dir}")
+    # Check if the directory is not empty
+    file(GLOB dir_contents "${dir}/*")
+
+    if(dir_contents)
+      set(${result_var} TRUE PARENT_SCOPE)
     else()
-        set(${result_var} FALSE PARENT_SCOPE)
-        message(STATUS "Directory ${dir} does not exist!")
+      set(${result_var} FALSE PARENT_SCOPE)
+      message(STATUS "Directory ${dir} exists but is empty!")
     endif()
+  else()
+    set(${result_var} FALSE PARENT_SCOPE)
+    message(STATUS "Directory ${dir} does not exist!")
+  endif()
 endfunction()
 
 # libmpv archive containing the pre-built shared libraries & headers.
-set(LIBMPV "mpv-dev-x86_64-20230825-git-c0fb9b4.7z")
+set(LIBMPV "mpv-dev-x86_64-20230924-git-652a1dd.7z")
 
 # Download URL & MD5 hash of the libmpv archive.
-set(LIBMPV_URL "https://github.com/media-kit/libmpv-win32-video-build/releases/download/2023-08-25/${LIBMPV}")
-set(LIBMPV_MD5 "cab756b2491897f7cc5e4f17fddf6793")
+set(LIBMPV_URL "https://github.com/media-kit/libmpv-win32-video-build/releases/download/2023-09-24/${LIBMPV}")
+set(LIBMPV_MD5 "a832ef24b3a6ff97cd2560b5b9d04cd8")
 
 # Download location of the libmpv archive.
 set(LIBMPV_ARCHIVE "${CMAKE_BINARY_DIR}/${LIBMPV}")

--- a/media_kit/CHANGELOG.md
+++ b/media_kit/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.1.8
+
+- fix: reset subtitle state/stream in `Player.setSubtitleTrack`
+- fix: explicit comparator in `PlayerStream` `Stream.distinct`
+- fix: add `rtp` & `udp` to `protocol_whitelist` by default
+- fix: reset `Player` state/stream upon `Player.open`
+- fix: `Player.stop` memory leak
+- fix(web): do not throw `UnsupportedError` w/ `SubtitleTrack.(auto|no)`
+- perf: move `NativePlayer.seek` to `Isolate`
+- build: update `package:uuid` version constraint
+
 ## 1.1.7
 
 - fix: close `PlatformPlayer.playlistModeController`

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -38,17 +38,17 @@
 
 ```yaml
 dependencies:
-  media_kit: ^1.1.7                              # Primary package.
-  media_kit_video: ^1.1.8                        # For video rendering.
-  media_kit_libs_video: ^1.0.1                   # Native video dependencies.
+  media_kit: ^1.1.8                              # Primary package.
+  media_kit_video: ^1.1.9                        # For video rendering.
+  media_kit_libs_video: ^1.0.2                   # Native video dependencies.
 ```
 
 #### For apps that need audio playback:
 
 ```yaml
 dependencies:
-  media_kit: ^1.1.7                              # Primary package.  
-  media_kit_libs_audio: ^1.0.1                   # Native audio dependencies.
+  media_kit: ^1.1.8                              # Primary package.  
+  media_kit_libs_audio: ^1.0.2                   # Native audio dependencies.
 ```
 
 **Notes:**
@@ -62,11 +62,11 @@ dependencies:
 
 | Platform | Video | Audio | Notes | Demo |
 | -------- | ----- | ----- | ----- | ---- |
-| Android     | ✅    | ✅    | Android 5.0 or above.                | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_android-arm64-v8a.apk) |
-| iOS         | ✅    | ✅    | iOS 9 or above.                      | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_ios_arm64.7z)          |
-| macOS       | ✅    | ✅    | macOS 10.9 or above.                 | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_macos_universal.7z)    |
-| Windows     | ✅    | ✅    | Windows 7 or above.                  | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_win32_x64.7z)          |
-| GNU/Linux   | ✅    | ✅    | Any modern GNU/Linux distribution.   | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.7/media_kit_test_linux_x64.7z)          |
+| Android     | ✅    | ✅    | Android 5.0 or above.                | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_android-arm64-v8a.apk) |
+| iOS         | ✅    | ✅    | iOS 9 or above.                      | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_ios_arm64.7z)          |
+| macOS       | ✅    | ✅    | macOS 10.9 or above.                 | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_macos_universal.7z)    |
+| Windows     | ✅    | ✅    | Windows 7 or above.                  | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_win32_x64.7z)          |
+| GNU/Linux   | ✅    | ✅    | Any modern GNU/Linux distribution.   | [Download](https://github.com/media-kit/media-kit/releases/download/media_kit-v1.1.8/media_kit_test_linux_x64.7z)          |
 | Web         | ✅    | ✅    | Any modern web browser.              | [Visit](https://media-kit.github.io/media-kit/)                                                                            |
 
 

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -1521,18 +1521,18 @@ Edit `android/app/src/main/AndroidManifest.xml` to add the following permissions
       -->
     <uses-permission android:name="android.permission.INTERNET" />
     <!--
-      Storage access permissions.
-      Android 12 or lower.
-      -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <!--
       Media access permissions.
       Android 13 or higher.
       https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions
       -->
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <!--
+      Storage access permissions.
+      Android 12 or lower.
+      -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>
 ```
 
@@ -1540,21 +1540,23 @@ Use [`package:permission_handler`](https://pub.dev/packages/permission_handler) 
 
 ```dart
 if (/* Android 13 or higher. */) {
-  if (await Permission.storage.isDenied || await Permission.storage.isPermanentlyDenied) {
-    final state = await Permission.storage.request();
+  // Video permissions.
+  if (await Permission.videos.isDenied || await Permission.videos.isPermanentlyDenied) {
+    final state = await Permission.videos.request();
     if (!state.isGranted) {
       await SystemNavigator.pop();
     }
   }
-} else {
+  // Audio permissions.
   if (await Permission.audio.isDenied || await Permission.audio.isPermanentlyDenied) {
     final state = await Permission.audio.request();
     if (!state.isGranted) {
       await SystemNavigator.pop();
     }
   }
-  if (await Permission.videos.isDenied || await Permission.videos.isPermanentlyDenied) {
-    final state = await Permission.videos.request();
+} else {
+  if (await Permission.storage.isDenied || await Permission.storage.isPermanentlyDenied) {
+    final state = await Permission.storage.request();
     if (!state.isGranted) {
       await SystemNavigator.pop();
     }

--- a/media_kit/pubspec.yaml
+++ b/media_kit/pubspec.yaml
@@ -2,7 +2,7 @@ name: media_kit
 description: A cross-platform video player & audio player for Flutter & Dart. Performant, stable, feature-proof & modular.
 homepage: https://github.com/media-kit/media-kit
 repository: https://github.com/media-kit/media-kit
-version: 1.1.7
+version: 1.1.8
 
 screenshots:
   - description: "package:media_kit running on Android (visible controls)"

--- a/media_kit_native_event_loop/CHANGELOG.md
+++ b/media_kit_native_event_loop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+- fix(windows): graceful process exit
+
 ## 1.0.7
 
 - build(darwin): bump `mpv` headers to `0.36.0`

--- a/media_kit_native_event_loop/example/README.md
+++ b/media_kit_native_event_loop/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_native_event_loop: ^1.0.7
+  media_kit_native_event_loop: ^1.0.8
 ```
 
 This will automatically allow using higher number of concurrent instances.

--- a/media_kit_native_event_loop/pubspec.yaml
+++ b/media_kit_native_event_loop/pubspec.yaml
@@ -2,7 +2,7 @@ name: media_kit_native_event_loop
 description: Platform specific threaded event handling for media_kit. Enables support for higher number of concurrent instances.
 homepage: https://github.com/media-kit/media-kit
 repository: https://github.com/media-kit/media-kit
-version: 1.0.7
+version: 1.0.8
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/media_kit_video/CHANGELOG.md
+++ b/media_kit_video/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.1.9
+
+- fix: unmount `CircularProgressIndicator` buffering indicator if invisible
+- fix: pass all video attributes to fullscreen route
+- fix: prevent controls from hiding during seek
+- fix: hide last video's frame upon `Player.open`
+- fix: `ThemeData.copyWith` override
+- fix(android): `hwdec=auto-safe` w/ `enableHardwareAcceleration=true`
+- fix(windows): fullscreen for non-primary monitors
+- fix(darwin): `mpv_render_context_free` call
+- fix(darwin): memory leaks
+- fix(ios): fix `disposeMPV`
+- feat: `VideoControllerConfiguration.androidAttachSurfaceAfterVideoParameters`
+- feat: center the seek-bar within its parent `Container` for improved tap area
+- feat: `backdropColor` argument in `MaterialVideoControlsThemeData`
+
 ## 1.1.8
 
 - fix: pass all `*VideoControlsTheme`(s) to fullscreen `context`

--- a/media_kit_video/pubspec.yaml
+++ b/media_kit_video/pubspec.yaml
@@ -2,7 +2,7 @@ name: media_kit_video
 description: Native implementation for video playback in package:media_kit.
 homepage: https://github.com/media-kit/media-kit
 repository: https://github.com/media-kit/media-kit
-version: 1.1.8
+version: 1.1.9
 topics:
   - video
   - video-player
@@ -19,7 +19,7 @@ dependencies:
     sdk: flutter
 
   # NOTE: Bump before publishing to pub.dev
-  media_kit: ^1.1.7
+  media_kit: ^1.1.8
 
   synchronized: ^3.1.0
   wakelock_plus: ^1.1.1


### PR DESCRIPTION
A big thanks to all the contributors.

#### media_kit: v1.1.8

- fix: reset subtitle state/stream in `Player.setSubtitleTrack`
- fix: explicit comparator in `PlayerStream` `Stream.distinct`
- fix: add `rtp` & `udp` to `protocol_whitelist` by default
- fix: reset `Player` state/stream upon `Player.open`
- fix: `Player.stop` memory leak
- fix(web): do not throw `UnsupportedError` w/ `SubtitleTrack.(auto|no)`
- perf: move `NativePlayer.seek` to `Isolate`
- build: update `package:uuid` version constraint

#### media_kit_video: v1.1.9

- fix: unmount `CircularProgressIndicator` buffering indicator if invisible
- fix: pass all video attributes to fullscreen route
- fix: prevent controls from hiding during seek
- fix: hide last video's frame upon `Player.open`
- fix: `ThemeData.copyWith` override
- fix(android): `hwdec=auto-safe` w/ `enableHardwareAcceleration=true`
- fix(windows): fullscreen for non-primary monitors
- fix(darwin): `mpv_render_context_free` call
- fix(darwin): memory leaks
- fix(ios): fix `disposeMPV`
- feat: `VideoControllerConfiguration.androidAttachSurfaceAfterVideoParameters`
- feat: center the seek-bar within its parent `Container` for improved tap area
- feat: `backdropColor` argument in `MaterialVideoControlsThemeData`

... and number of fixes within the platform-specific native libraries.