### PR TITLE
Add profile and options for native MPV player

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2367,8 +2367,7 @@ class NativePlayer extends PlatformPlayer {
         },
       );
 
-      properties
-          .addEntries((configuration.options ?? <String, String>{}).entries);
+      properties.addAll(configuration.options ?? <String, String>{});
 
       if (test) {
         properties['vo'] = 'null';

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2362,8 +2362,13 @@ class NativePlayer extends PlatformPlayer {
           'sub-ass': configuration.libass ? 'yes' : 'no',
           'sub-visibility': configuration.libass ? 'yes' : 'no',
           'secondary-sub-visibility': configuration.libass ? 'yes' : 'no',
+          if (configuration.profile?.name != null)
+            'profile': configuration.profile?.name ?? 'null',
         },
       );
+
+      properties
+          .addEntries((configuration.options ?? <String, String>{}).entries);
 
       if (test) {
         properties['vo'] = 'null';

--- a/media_kit/lib/src/player/platform_player.dart
+++ b/media_kit/lib/src/player/platform_player.dart
@@ -471,7 +471,7 @@ class PlayerConfiguration {
 
   /// Sets the demuxer cache size (in bytes) for native backend.
   ///
-  /// Default: `32` MB or `32 * 1024 * 1024` bytes.
+  /// Default: `128` MB or `128 * 1024 * 1024` bytes.
   final int bufferSize;
 
   /// Sets the list of allowed protocols for native backend.
@@ -480,6 +480,16 @@ class PlayerConfiguration {
   ///
   /// Learn more: https://ffmpeg.org/ffmpeg-protocols.html#Protocol-Options
   final List<String> protocolWhitelist;
+
+  /// Sets the map for the optional configuration.
+  ///
+  /// Learn more: https://mpv.io/manual/master/#options
+  final Map<String, String>? options;
+
+  /// Sets the MPV profile.
+  ///
+  /// Learn more: https://mpv.io/manual/master/#profiles
+  final MPVProfile? profile;
 
   /// {@macro player_configuration}
   const PlayerConfiguration({
@@ -503,6 +513,8 @@ class PlayerConfiguration {
       'https',
       'crypto',
     ],
+    this.options,
+    this.profile,
   });
 }
 
@@ -539,4 +551,28 @@ enum MPVLogLevel {
 
   /// Extremely noisy.
   trace,
+}
+
+/// MPVProfile
+/// --------------------
+/// Options to customize the build in profile for [Player] native backend.
+enum MPVProfile {
+  highQuality,
+  bigCache,
+  lowLatency,
+}
+
+extension MPVProfileExtension on MPVProfile {
+  String? get name {
+    switch (this) {
+      case MPVProfile.highQuality:
+        return 'high-quality';
+      case MPVProfile.bigCache:
+        return 'big-cache';
+      case MPVProfile.lowLatency:
+        return 'low-latency';
+      default:
+        return null;
+    }
+  }
 }


### PR DESCRIPTION
When working with the camera and viewing the RTSP stream it is required to playback video without delay - for example, during PTZ control. This requires calling the native low-latency profile and setting the untimed flag.

This solution will help to customize and use the player more flexibly.

For example:

`final player = Player(configuration: const PlayerConfiguration(bufferSize: 1 * 1024 * 1024, profile: MPVProfile.lowLatency, options: {'untimed':'yes'}));`