### PR TITLE
fix(darwin): move `FlutterTextureRegistry.register` to main thread

### DIFF
--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -115,6 +115,15 @@ public class VideoOutput: NSObject {
       )
     }
 
+    DispatchQueue.main.async { [weak self]() in
+      guard let that = self else {
+        return
+      }
+      that.registerTextureId()
+    }
+  }
+
+  private func registerTextureId() {
     textureId = registry.register(texture)
     textureUpdateCallback(textureId, CGSize(width: 0, height: 0))
   }


### PR DESCRIPTION
Ref: https://github.com/flutter/flutter/issues/135345#issuecomment-1774328128

<hr>

The macOS & iOS side is built by @birros. Let's see if this is right...