### PR TITLE
auto hide mouse

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -64,6 +64,9 @@ class MaterialDesktopVideoControlsThemeData {
   /// Whether to toggle fullscreen on double press.
   final bool toggleFullscreenOnDoublePress;
 
+  /// Whether to hide mouse on controls removal.(will need to move the mouse to be hidden check issue: https://github.com/flutter/flutter/issues/76622) works on macos without moving the mouse
+  final bool hideMouseOnControlsRemoval;
+
   /// Keyboards shortcuts.
   final Map<ShortcutActivator, VoidCallback>? keyboardShortcuts;
 
@@ -182,6 +185,7 @@ class MaterialDesktopVideoControlsThemeData {
     this.modifyVolumeOnScroll = true,
     this.keyboardShortcuts,
     this.visibleOnMount = false,
+    this.hideMouseOnControlsRemoval = false,
     this.padding,
     this.controlsHoverDuration = const Duration(seconds: 3),
     this.controlsTransitionDuration = const Duration(milliseconds: 150),
@@ -231,6 +235,7 @@ class MaterialDesktopVideoControlsThemeData {
     bool? modifyVolumeOnScroll,
     Map<ShortcutActivator, VoidCallback>? keyboardShortcuts,
     bool? visibleOnMount,
+    bool? hideMouseOnControlsRemoval,
     Duration? controlsHoverDuration,
     Duration? controlsTransitionDuration,
     Widget Function(BuildContext)? bufferingIndicatorBuilder,
@@ -272,6 +277,8 @@ class MaterialDesktopVideoControlsThemeData {
       modifyVolumeOnScroll: modifyVolumeOnScroll ?? this.modifyVolumeOnScroll,
       keyboardShortcuts: keyboardShortcuts ?? this.keyboardShortcuts,
       visibleOnMount: visibleOnMount ?? this.visibleOnMount,
+      hideMouseOnControlsRemoval:
+          hideMouseOnControlsRemoval ?? this.hideMouseOnControlsRemoval,
       controlsHoverDuration:
           controlsHoverDuration ?? this.controlsHoverDuration,
       bufferingIndicatorBuilder:
@@ -617,6 +624,9 @@ class _MaterialDesktopVideoControlsState
                       }
                     : null,
                 child: MouseRegion(
+                  cursor: (_theme(context).hideMouseOnControlsRemoval && !mount)
+                      ? SystemMouseCursors.none
+                      : SystemMouseCursors.basic,
                   onHover: (_) => onHover(),
                   onEnter: (_) => onEnter(),
                   onExit: (_) => onExit(),


### PR DESCRIPTION
# Add Feature to Hide Mouse on Controls Removal

## Overview
This pull request introduces a new feature to the `MaterialDesktopVideoControlsThemeData` in the `material_desktop.dart` file of the `media_kit_video_controls` library. The primary addition is the `hideMouseOnControlsRemoval` property.

## Changes
- **New Property Added**: `hideMouseOnControlsRemoval`
  - This boolean property, when set to `true`, will hide the mouse cursor when the video controls are removed. This feature enhances the user experience by providing a cleaner view, especially useful in a full-screen video context.
  - The default value is set to `false` to maintain backward compatibility and avoid altering the current behavior for existing users.
  - A relevant comment has been added to explain the behavior and its current limitations on different platforms.
- **Comments and Documentation**:
  - Added a detailed comment explaining the functionality and a link to the related GitHub issue ([#76622](https://github.com/flutter/flutter/issues/76622)) for further context. This issue discusses the platform-specific behavior of the mouse hiding functionality, notably its distinct behavior on macOS.

## Usage
Users can now opt to hide the mouse cursor when the video controls are removed by setting the `hideMouseOnControlsRemoval` flag in the `MaterialDesktopVideoControlsThemeData` constructor.

Example:
```dart
MaterialDesktopVideoControlsThemeData(
  // ... other properties ...
  hideMouseOnControlsRemoval: true,
)
