### PR TITLE
Update native_library.dart

### DIFF
--- a/media_kit/lib/src/player/native/core/native_library.dart
+++ b/media_kit/lib/src/player/native/core/native_library.dart
@@ -71,6 +71,7 @@ abstract class NativeLibrary {
         try {
           DynamicLibrary.open(name);
           _resolved = name;
+          return;
         } catch (_) {}
       }
       // If the dynamic library is not loaded, throw an [Exception].


### PR DESCRIPTION
Fix errror of loop finding mpv dlls.  

Loop finding dlls will cause exception on Windows platform even though libmpv-2.dll has being founded.  

The fixed exception is:
Exception has occurred.
ArgumentError (Invalid argument(s): Failed to load dynamic library 'mpv-2.dll': error code 126)