### PR TITLE
fix: (maybe) Adjust cmake options to have them not try to  define pthread

### DIFF
--- a/media_kit_video/linux/CMakeLists.txt
+++ b/media_kit_video/linux/CMakeLists.txt
@@ -38,9 +38,10 @@ if(MEDIA_KIT_LIBS_AVAILABLE)
   target_compile_definitions(
     ${PLUGIN_NAME} PRIVATE
     FLUTTER_PLUGIN_IMPL
-    "${mpv_CFLAGS_OTHER}"
-    "${epoxy_CFLAGS_OTHER}"
   )
+  
+  target_compile_options(${PLUGIN_NAME} PRIVATE "${mpv_CFLAGS_OTHER}")
+  target_compile_options(${PLUGIN_NAME} PRIVATE "${epoxy_CFLAGS_OTHER}")
 
   target_include_directories(
     ${PLUGIN_NAME} INTERFACE


### PR DESCRIPTION
This should fix issue 595 about building on fedora. It no longer tries to add the definitions that were coming from cflags :/