### PR TITLE
fixed stuck double tap

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -1278,7 +1278,7 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                               ? TweenAnimationBuilder<double>(
                                   tween: Tween<double>(
                                     begin: 0.0,
-                                    end: _hideSeekBackwardButton ? 0.0 : 1.0,
+                                    end: _hideSeekBackwardButton ? 0.000001 : 1.0,
                                   ),
                                   duration: const Duration(milliseconds: 200),
                                   builder: (context, value, child) => Opacity(
@@ -1324,7 +1324,7 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                               ? TweenAnimationBuilder<double>(
                                   tween: Tween<double>(
                                     begin: 0.0,
-                                    end: _hideSeekForwardButton ? 0.0 : 1.0,
+                                    end: _hideSeekForwardButton ? 0.000001 : 1.0,
                                   ),
                                   duration: const Duration(milliseconds: 200),
                                   builder: (context, value, child) => Opacity(
@@ -1347,6 +1347,7 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                       setState(() {
                                         _hideSeekForwardButton = true;
                                       });
+
                                       var result = controller(context)
                                               .player
                                               .state


### PR DESCRIPTION

### Issue Description
- **Problem:** The seek buttons in the video controls were incorrectly remaining hidden while still registering clicks. 
- **Cause:** This behavior was due to both `_hideSeekForwardButton` and `_mountSeekForwardButton` being set to `true` at the same time. The root cause of this issue was traced back to the `TweenAnimationBuilder`'s end value being set to zero which prevents onend from being called.

### Proposed Solution
- **Fix Implementation:** The proposed fix involves a minor yet critical adjustment to the `TweenAnimationBuilder`.
- **Details:**
    - Change the end value from `0.0` to a minimal non-zero value (`0.000001`).
    - This adjustment allows the 'on end' callback to be called to hide and unmount the UI elements.





