### PR TITLE
Center instant show controls

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -141,12 +141,23 @@ class MaterialVideoControlsThemeData {
   /// NOTE: This option is ignored when [seekOnDoubleTap] is false.
   final bool seekOnDoubleTapEnabledWhileControlsVisible;
 
-  /// Defines widget's width proportions for double tap actions: `[left seek, instant tap, forward seek]`.
-  /// Each integer represents segment width ratio. Default `[1, 1, 1]` means equal segments.
+  /// `seekOnDoubleTapLayoutTapsRatios` defines the width proportions for the interactive areas
+  /// responsible for seek actions (backward seek, instant tap, forward seek) when a double tap
+  /// occurs on the video widget. This property divides the video widget into three segments
+  /// horizontally. Each integer in the list represents the relative width of each segment.
+  /// By default, the value `[1, 1, 1]` means that the video widget is equally divided into three
+  /// segments: the left segment for backward seek, the middle segment for instant tap (usually show and hide controls),
+  /// and the right segment for forward seek. Adjusting these values changes the width of the interactive areas
+  /// for each double tap action.
   final List<int> seekOnDoubleTapLayoutTapsRatios;
 
-  /// Defines widget's width proportions for double tap actions: `[left seek, instant tap, forward seek]`.
-  /// Each integer represents segment width ratio. Default `[1, 1, 1]` means equal segments.
+  /// `seekOnDoubleTapLayoutWidgetRatios` defines the width proportions for the visual indicators or
+  /// widgets that appear during the double tap actions (backward seek, instant tap, forward seek).
+  /// Similar to `seekOnDoubleTapLayoutTapsRatios`, it divides the area where these indicators are
+  /// displayed into three segments. Each integer in the list represents the relative width of each
+  /// segment where the corresponding indicators will be shown. The default `[1, 1, 1]` equally divides
+  /// the space for each indicator. Modifying these values can change the layout of the seek indicators,
+  /// giving more or less space to each one based on the specified ratios.
   final List<int> seekOnDoubleTapLayoutWidgetRatios;
 
   /// Whether the controls are initially visible.

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -501,7 +501,7 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
           : 0.0);
   Offset? _tapPosition;
 
-  void _handleTapDown(TapDownDetails details) {
+  void _handleDoubleTapDown(TapDownDetails details) {
     setState(() {
       _tapPosition = details.localPosition;
     });
@@ -683,6 +683,28 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
     });
   }
 
+  void _handlePointerDown(PointerDownEvent event, double widgetWidth) {
+    // Calculate the third of the widget width
+    double thirdWidth = widgetWidth / 3;
+
+    // Check if the click is in the center third of the widget
+    if (event.position.dx >= thirdWidth &&
+        event.position.dx <= 2 * thirdWidth) {
+      onTap();
+    }
+  }
+
+  void _handleTapDown(TapDownDetails details, double widgetWidth) {
+    // Calculate the third of the widget width
+    double thirdWidth = widgetWidth / 3;
+
+    // Check if the click is in the center third of the widget
+    if (!(details.localPosition.dx >= thirdWidth &&
+        details.localPosition.dx <= 2 * thirdWidth)) {
+      onTap();
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -774,604 +796,625 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
         splashColor: const Color(0x00000000),
         highlightColor: const Color(0x00000000),
       ),
-      child: Focus(
-        autofocus: true,
-        child: Material(
-          elevation: 0.0,
-          borderOnForeground: false,
-          animationDuration: Duration.zero,
-          color: const Color(0x00000000),
-          shadowColor: const Color(0x00000000),
-          surfaceTintColor: const Color(0x00000000),
-          child: Stack(
-            clipBehavior: Clip.none,
-            alignment: Alignment.center,
-            children: [
-              // Controls:
-              AnimatedOpacity(
-                curve: Curves.easeInOut,
-                opacity: visible ? 1.0 : 0.0,
-                duration: _theme(context).controlsTransitionDuration,
-                onEnd: () {
-                  setState(() {
-                    if (!visible) {
-                      mount = false;
-                    }
-                  });
-                },
-                child: Stack(
-                  clipBehavior: Clip.none,
-                  alignment: Alignment.center,
-                  children: [
-                    Positioned.fill(
-                      child: Container(
-                        color: _theme(context).backdropColor,
-                      ),
-                    ),
-                    // We are adding 16.0 boundary around the actual controls (which contain the vertical drag gesture detectors).
-                    // This will make the hit-test on edges (e.g. swiping to: show status-bar, show navigation-bar, go back in navigation) not activate the swipe gesture annoyingly.
-                    Positioned.fill(
-                      left: 16.0,
-                      top: 16.0,
-                      right: 16.0,
-                      bottom: 16.0,
-                      child: GestureDetector(
-                        onTap: onTap,
-                        onDoubleTapDown: _handleTapDown,
-                        onLongPress: _theme(context).speedUpOnLongPress
-                            ? _handleLongPress
-                            : null,
-                        onLongPressEnd: _theme(context).speedUpOnLongPress
-                            ? _handleLongPressEnd
-                            : null,
-                        onDoubleTap: () {
-                          if (_tapPosition != null &&
-                              _tapPosition!.dx >
-                                  MediaQuery.of(context).size.width / 2) {
-                            if ((!mount && _theme(context).seekOnDoubleTap) ||
-                                seekOnDoubleTapEnabledWhileControlsAreVisible) {
-                              onDoubleTapSeekForward();
-                            }
-                          } else {
-                            if ((!mount && _theme(context).seekOnDoubleTap) ||
-                                seekOnDoubleTapEnabledWhileControlsAreVisible) {
-                              onDoubleTapSeekBackward();
-                            }
-                          }
-                        },
-                        onHorizontalDragUpdate: (details) {
-                          if ((!mount && _theme(context).seekGesture) ||
-                              (_theme(context).seekGesture &&
-                                  _theme(context)
-                                      .gesturesEnabledWhileControlsVisible)) {
-                            onHorizontalDragUpdate(details);
-                          }
-                        },
-                        onHorizontalDragEnd: (details) {
-                          onHorizontalDragEnd();
-                        },
-                        onVerticalDragUpdate: (e) async {
-                          final delta = e.delta.dy;
-                          final Offset position = e.localPosition;
-
-                          if (position.dx <=
-                              MediaQuery.of(context).size.width / 2) {
-                            // Left side of screen swiped
-
-                            if ((!mount && _theme(context).brightnessGesture) ||
-                                (_theme(context).brightnessGesture &&
-                                    _theme(context)
-                                        .gesturesEnabledWhileControlsVisible)) {
-                              final brightness = _brightnessValue -
-                                  delta /
-                                      _theme(context)
-                                          .verticalGestureSensitivity;
-                              final result = brightness.clamp(0.0, 1.0);
-                              setBrightness(result);
-                            }
-                          } else {
-                            // Right side of screen swiped
-
-                            if ((!mount && _theme(context).volumeGesture) ||
-                                (_theme(context).volumeGesture &&
-                                    _theme(context)
-                                        .gesturesEnabledWhileControlsVisible)) {
-                              final volume = _volumeValue -
-                                  delta /
-                                      _theme(context)
-                                          .verticalGestureSensitivity;
-                              final result = volume.clamp(0.0, 1.0);
-                              setVolume(result);
-                            }
-                          }
-                        },
+      child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+        double widgetWidth = constraints.maxWidth;
+        double widgetHeight = constraints.maxHeight;
+        return Focus(
+          autofocus: true,
+          child: Material(
+            elevation: 0.0,
+            borderOnForeground: false,
+            animationDuration: Duration.zero,
+            color: const Color(0x00000000),
+            shadowColor: const Color(0x00000000),
+            surfaceTintColor: const Color(0x00000000),
+            child: Stack(
+              clipBehavior: Clip.none,
+              alignment: Alignment.center,
+              children: [
+                // Controls:
+                AnimatedOpacity(
+                  curve: Curves.easeInOut,
+                  opacity: visible ? 1.0 : 0.0,
+                  duration: _theme(context).controlsTransitionDuration,
+                  onEnd: () {
+                    setState(() {
+                      if (!visible) {
+                        mount = false;
+                      }
+                    });
+                  },
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    alignment: Alignment.center,
+                    children: [
+                      Positioned.fill(
                         child: Container(
-                          color: const Color(0x00000000),
+                          color: _theme(context).backdropColor,
                         ),
                       ),
-                    ),
-                    if (mount)
-                      Padding(
-                        padding: _theme(context).padding ??
-                            (
-                                // Add padding in fullscreen!
-                                isFullscreen(context)
-                                    ? MediaQuery.of(context).padding
-                                    : EdgeInsets.zero),
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          mainAxisAlignment: MainAxisAlignment.start,
-                          crossAxisAlignment: CrossAxisAlignment.end,
+                      // We are adding 16.0 boundary around the actual controls (which contain the vertical drag gesture detectors).
+                      // This will make the hit-test on edges (e.g. swiping to: show status-bar, show navigation-bar, go back in navigation) not activate the swipe gesture annoyingly.
+                      Positioned.fill(
+                        left: 16.0,
+                        top: 16.0,
+                        right: 16.0,
+                        bottom: 16.0,
+                        child: Listener(
+                          onPointerDown: (event) =>
+                              _handlePointerDown(event, widgetWidth),
+                          child: GestureDetector(
+                            onTapDown: (details) =>
+                                _handleTapDown(details, widgetWidth),
+                            // onTap: onTap,
+                            onDoubleTapDown: _handleDoubleTapDown,
+                            onLongPress: _theme(context).speedUpOnLongPress
+                                ? _handleLongPress
+                                : null,
+                            onLongPressEnd: _theme(context).speedUpOnLongPress
+                                ? _handleLongPressEnd
+                                : null,
+                            onDoubleTap: () {
+                              if (_tapPosition != null &&
+                                  _tapPosition!.dx > widgetWidth / 2) {
+                                if ((!mount &&
+                                        _theme(context).seekOnDoubleTap) ||
+                                    seekOnDoubleTapEnabledWhileControlsAreVisible) {
+                                  onDoubleTapSeekForward();
+                                }
+                              } else {
+                                if ((!mount &&
+                                        _theme(context).seekOnDoubleTap) ||
+                                    seekOnDoubleTapEnabledWhileControlsAreVisible) {
+                                  onDoubleTapSeekBackward();
+                                }
+                              }
+                            },
+                            onHorizontalDragUpdate: (details) {
+                              if ((!mount && _theme(context).seekGesture) ||
+                                  (_theme(context).seekGesture &&
+                                      _theme(context)
+                                          .gesturesEnabledWhileControlsVisible)) {
+                                onHorizontalDragUpdate(details);
+                              }
+                            },
+                            onHorizontalDragEnd: (details) {
+                              onHorizontalDragEnd();
+                            },
+                            onVerticalDragUpdate: (e) async {
+                              final delta = e.delta.dy;
+                              final Offset position = e.localPosition;
+
+                              if (position.dx <= widgetWidth / 2) {
+                                // Left side of screen swiped
+                                if ((!mount &&
+                                        _theme(context).brightnessGesture) ||
+                                    (_theme(context).brightnessGesture &&
+                                        _theme(context)
+                                            .gesturesEnabledWhileControlsVisible)) {
+                                  final brightness = _brightnessValue -
+                                      delta /
+                                          _theme(context)
+                                              .verticalGestureSensitivity;
+                                  final result = brightness.clamp(0.0, 1.0);
+                                  setBrightness(result);
+                                }
+                              } else {
+                                // Right side of screen swiped
+
+                                if ((!mount && _theme(context).volumeGesture) ||
+                                    (_theme(context).volumeGesture &&
+                                        _theme(context)
+                                            .gesturesEnabledWhileControlsVisible)) {
+                                  final volume = _volumeValue -
+                                      delta /
+                                          _theme(context)
+                                              .verticalGestureSensitivity;
+                                  final result = volume.clamp(0.0, 1.0);
+                                  setVolume(result);
+                                }
+                              }
+                            },
+                            child: Container(
+                              color: const Color(0x00000000),
+                            ),
+                          ),
+                        ),
+                      ),
+                      if (mount)
+                        Padding(
+                          padding: _theme(context).padding ??
+                              (
+                                  // Add padding in fullscreen!
+                                  isFullscreen(context)
+                                      ? MediaQuery.of(context).padding
+                                      : EdgeInsets.zero),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: [
+                              Container(
+                                height: _theme(context).buttonBarHeight,
+                                margin: _theme(context).topButtonBarMargin,
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.max,
+                                  mainAxisAlignment: MainAxisAlignment.start,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: _theme(context).topButtonBar,
+                                ),
+                              ),
+                              // Only display [primaryButtonBar] if [buffering] is false.
+                              Expanded(
+                                child: AnimatedOpacity(
+                                  curve: Curves.easeInOut,
+                                  opacity: buffering ? 0.0 : 1.0,
+                                  duration: _theme(context)
+                                      .controlsTransitionDuration,
+                                  child: Center(
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.center,
+                                      children:
+                                          _theme(context).primaryButtonBar,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              Stack(
+                                alignment: Alignment.bottomCenter,
+                                children: [
+                                  if (_theme(context).displaySeekBar)
+                                    MaterialSeekBar(
+                                      onSeekStart: () {
+                                        _timer?.cancel();
+                                      },
+                                      onSeekEnd: () {
+                                        _timer = Timer(
+                                          _theme(context).controlsHoverDuration,
+                                          () {
+                                            if (mounted) {
+                                              setState(() {
+                                                visible = false;
+                                              });
+                                              unshiftSubtitle();
+                                            }
+                                          },
+                                        );
+                                      },
+                                    ),
+                                  Container(
+                                    height: _theme(context).buttonBarHeight,
+                                    margin:
+                                        _theme(context).bottomButtonBarMargin,
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.max,
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.center,
+                                      children: _theme(context).bottomButtonBar,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                // Double-Tap Seek Seek-Bar:
+                if (!mount)
+                  if (_mountSeekBackwardButton ||
+                      _mountSeekForwardButton ||
+                      showSwipeDuration)
+                    Column(
+                      children: [
+                        const Spacer(),
+                        Stack(
+                          alignment: Alignment.bottomCenter,
                           children: [
+                            if (_theme(context).displaySeekBar)
+                              MaterialSeekBar(
+                                delta: _seekBarDeltaValueNotifier,
+                              ),
                             Container(
                               height: _theme(context).buttonBarHeight,
-                              margin: _theme(context).topButtonBarMargin,
-                              child: Row(
-                                mainAxisSize: MainAxisSize.max,
-                                mainAxisAlignment: MainAxisAlignment.start,
-                                crossAxisAlignment: CrossAxisAlignment.center,
-                                children: _theme(context).topButtonBar,
-                              ),
-                            ),
-                            // Only display [primaryButtonBar] if [buffering] is false.
-                            Expanded(
-                              child: AnimatedOpacity(
-                                curve: Curves.easeInOut,
-                                opacity: buffering ? 0.0 : 1.0,
-                                duration:
-                                    _theme(context).controlsTransitionDuration,
-                                child: Center(
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: _theme(context).primaryButtonBar,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            Stack(
-                              alignment: Alignment.bottomCenter,
-                              children: [
-                                if (_theme(context).displaySeekBar)
-                                  MaterialSeekBar(
-                                    onSeekStart: () {
-                                      _timer?.cancel();
-                                    },
-                                    onSeekEnd: () {
-                                      _timer = Timer(
-                                        _theme(context).controlsHoverDuration,
-                                        () {
-                                          if (mounted) {
-                                            setState(() {
-                                              visible = false;
-                                            });
-                                            unshiftSubtitle();
-                                          }
-                                        },
-                                      );
-                                    },
-                                  ),
-                                Container(
-                                  height: _theme(context).buttonBarHeight,
-                                  margin: _theme(context).bottomButtonBarMargin,
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.max,
-                                    mainAxisAlignment: MainAxisAlignment.start,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: _theme(context).bottomButtonBar,
-                                  ),
-                                ),
-                              ],
+                              margin: _theme(context).bottomButtonBarMargin,
                             ),
                           ],
                         ),
-                      ),
-                  ],
-                ),
-              ),
-              // Double-Tap Seek Seek-Bar:
-              if (!mount)
-                if (_mountSeekBackwardButton ||
-                    _mountSeekForwardButton ||
-                    showSwipeDuration)
-                  Column(
-                    children: [
-                      const Spacer(),
-                      Stack(
-                        alignment: Alignment.bottomCenter,
-                        children: [
-                          if (_theme(context).displaySeekBar)
-                            MaterialSeekBar(
-                              delta: _seekBarDeltaValueNotifier,
-                            ),
-                          Container(
-                            height: _theme(context).buttonBarHeight,
-                            margin: _theme(context).bottomButtonBarMargin,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-              // Buffering Indicator.
-              IgnorePointer(
-                child: Padding(
-                  padding: _theme(context).padding ??
-                      (
-                          // Add padding in fullscreen!
-                          isFullscreen(context)
-                              ? MediaQuery.of(context).padding
-                              : EdgeInsets.zero),
-                  child: Column(
-                    children: [
-                      Container(
-                        height: _theme(context).buttonBarHeight,
-                        margin: _theme(context).topButtonBarMargin,
-                      ),
-                      Expanded(
-                        child: Center(
-                          child: TweenAnimationBuilder<double>(
-                            tween: Tween<double>(
-                              begin: 0.0,
-                              end: buffering ? 1.0 : 0.0,
-                            ),
-                            duration:
-                                _theme(context).controlsTransitionDuration,
-                            builder: (context, value, child) {
-                              // Only mount the buffering indicator if the opacity is greater than 0.0.
-                              // This has been done to prevent redundant resource usage in [CircularProgressIndicator].
-                              if (value > 0.0) {
-                                return Opacity(
-                                  opacity: value,
-                                  child: _theme(context)
-                                          .bufferingIndicatorBuilder
-                                          ?.call(context) ??
-                                      child!,
-                                );
-                              }
-                              return const SizedBox.shrink();
-                            },
-                            child: const CircularProgressIndicator(
-                              color: Color(0xFFFFFFFF),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Container(
-                        height: _theme(context).buttonBarHeight,
-                        margin: _theme(context).bottomButtonBarMargin,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              // Volume Indicator.
-              IgnorePointer(
-                child: AnimatedOpacity(
-                  curve: Curves.easeInOut,
-                  opacity: (!mount ||
-                              _theme(context)
-                                  .gesturesEnabledWhileControlsVisible) &&
-                          _volumeIndicator
-                      ? 1.0
-                      : 0.0,
-                  duration: _theme(context).controlsTransitionDuration,
-                  child: _theme(context)
-                          .volumeIndicatorBuilder
-                          ?.call(context, _volumeValue) ??
-                      Container(
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                          color: const Color(0x88000000),
-                          borderRadius: BorderRadius.circular(64.0),
-                        ),
-                        height: 52.0,
-                        width: 108.0,
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Container(
-                              height: 52.0,
-                              width: 42.0,
-                              alignment: Alignment.centerRight,
-                              child: Icon(
-                                _volumeValue == 0.0
-                                    ? Icons.volume_off
-                                    : _volumeValue < 0.5
-                                        ? Icons.volume_down
-                                        : Icons.volume_up,
-                                color: const Color(0xFFFFFFFF),
-                                size: 24.0,
-                              ),
-                            ),
-                            const SizedBox(width: 8.0),
-                            Expanded(
-                              child: Text(
-                                '${(_volumeValue * 100.0).round()}%',
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                  fontSize: 14.0,
-                                  color: Color(0xFFFFFFFF),
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 16.0),
-                          ],
-                        ),
-                      ),
-                ),
-              ),
-              // Brightness Indicator.
-              IgnorePointer(
-                child: AnimatedOpacity(
-                  curve: Curves.easeInOut,
-                  opacity: (!mount ||
-                              _theme(context)
-                                  .gesturesEnabledWhileControlsVisible) &&
-                          _brightnessIndicator
-                      ? 1.0
-                      : 0.0,
-                  duration: _theme(context).controlsTransitionDuration,
-                  child: _theme(context)
-                          .brightnessIndicatorBuilder
-                          ?.call(context, _volumeValue) ??
-                      Container(
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                          color: const Color(0x88000000),
-                          borderRadius: BorderRadius.circular(64.0),
-                        ),
-                        height: 52.0,
-                        width: 108.0,
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Container(
-                              height: 52.0,
-                              width: 42.0,
-                              alignment: Alignment.centerRight,
-                              child: Icon(
-                                _brightnessValue < 1.0 / 3.0
-                                    ? Icons.brightness_low
-                                    : _brightnessValue < 2.0 / 3.0
-                                        ? Icons.brightness_medium
-                                        : Icons.brightness_high,
-                                color: const Color(0xFFFFFFFF),
-                                size: 24.0,
-                              ),
-                            ),
-                            const SizedBox(width: 8.0),
-                            Expanded(
-                              child: Text(
-                                '${(_brightnessValue * 100.0).round()}%',
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                  fontSize: 14.0,
-                                  color: Color(0xFFFFFFFF),
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 16.0),
-                          ],
-                        ),
-                      ),
-                ),
-              ),
-              // Speedup Indicator.
-              IgnorePointer(
-                child: Padding(
-                  padding: _theme(context).padding ??
-                      (
-                          // Add padding in fullscreen!
-                          isFullscreen(context)
-                              ? MediaQuery.of(context).padding
-                              : EdgeInsets.zero),
-                  child: Column(
-                    children: [
-                      Container(
-                        height: _theme(context).buttonBarHeight,
-                        margin: _theme(context).topButtonBarMargin,
-                      ),
-                      Expanded(
-                        child: AnimatedOpacity(
-                          duration: _theme(context).controlsTransitionDuration,
-                          opacity: _speedUpIndicator ? 1 : 0,
-                          child: _theme(context).speedUpIndicatorBuilder?.call(
-                                  context, _theme(context).speedUpFactor) ??
-                              Container(
-                                alignment: Alignment.topCenter,
-                                child: Container(
-                                  margin: const EdgeInsets.all(16.0),
-                                  alignment: Alignment.center,
-                                  decoration: BoxDecoration(
-                                    color: const Color(0x88000000),
-                                    borderRadius: BorderRadius.circular(64.0),
-                                  ),
-                                  height: 48.0,
-                                  width: 108.0,
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: [
-                                      const SizedBox(width: 16.0),
-                                      Expanded(
-                                        child: Text(
-                                          '${_theme(context).speedUpFactor.toStringAsFixed(1)}x',
-                                          textAlign: TextAlign.center,
-                                          style: const TextStyle(
-                                            fontSize: 14.0,
-                                            color: Color(0xFFFFFFFF),
-                                          ),
-                                        ),
-                                      ),
-                                      Container(
-                                        height: 48.0,
-                                        width: 48.0 - 16.0,
-                                        alignment: Alignment.centerRight,
-                                        child: const Icon(
-                                          Icons.fast_forward,
-                                          color: Color(0xFFFFFFFF),
-                                          size: 24.0,
-                                        ),
-                                      ),
-                                      const SizedBox(width: 16.0),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                        ),
-                      ),
-                      Container(
-                        height: _theme(context).buttonBarHeight,
-                        margin: _theme(context).bottomButtonBarMargin,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              // Seek Indicator.
-              IgnorePointer(
-                child: AnimatedOpacity(
-                  duration: _theme(context).controlsTransitionDuration,
-                  opacity: showSwipeDuration ? 1 : 0,
-                  child: _theme(context)
-                          .seekIndicatorBuilder
-                          ?.call(context, Duration(seconds: swipeDuration)) ??
-                      Container(
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                          color: const Color(0x88000000),
-                          borderRadius: BorderRadius.circular(64.0),
-                        ),
-                        height: 52.0,
-                        width: 108.0,
-                        child: Text(
-                          swipeDuration > 0
-                              ? "+ ${Duration(seconds: swipeDuration).label()}"
-                              : "- ${Duration(seconds: swipeDuration).label()}",
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            fontSize: 14.0,
-                            color: Color(0xFFFFFFFF),
-                          ),
-                        ),
-                      ),
-                ),
-              ),
-
-              // Double-Tap Seek Button(s):
-              if (!mount || seekOnDoubleTapEnabledWhileControlsAreVisible)
-                if (_mountSeekBackwardButton || _mountSeekForwardButton)
-                  Positioned.fill(
-                    child: Row(
+                      ],
+                    ),
+                // Buffering Indicator.
+                IgnorePointer(
+                  child: Padding(
+                    padding: _theme(context).padding ??
+                        (
+                            // Add padding in fullscreen!
+                            isFullscreen(context)
+                                ? MediaQuery.of(context).padding
+                                : EdgeInsets.zero),
+                    child: Column(
                       children: [
-                        Expanded(
-                          child: _mountSeekBackwardButton
-                              ? TweenAnimationBuilder<double>(
-                                  tween: Tween<double>(
-                                    begin: 0.0,
-                                    end: _hideSeekBackwardButton ? 0.0 : 1.0,
-                                  ),
-                                  duration: const Duration(milliseconds: 200),
-                                  builder: (context, value, child) => Opacity(
-                                    opacity: value,
-                                    child: child,
-                                  ),
-                                  onEnd: () {
-                                    if (_hideSeekBackwardButton) {
-                                      setState(() {
-                                        _hideSeekBackwardButton = false;
-                                        _mountSeekBackwardButton = false;
-                                      });
-                                    }
-                                  },
-                                  child: _BackwardSeekIndicator(
-                                    onChanged: (value) {
-                                      _seekBarDeltaValueNotifier.value = -value;
-                                    },
-                                    onSubmitted: (value) {
-                                      setState(() {
-                                        _hideSeekBackwardButton = true;
-                                      });
-                                      var result = controller(context)
-                                              .player
-                                              .state
-                                              .position -
-                                          value;
-                                      result = result.clamp(
-                                        Duration.zero,
-                                        controller(context)
-                                            .player
-                                            .state
-                                            .duration,
-                                      );
-                                      controller(context).player.seek(result);
-                                    },
-                                  ),
-                                )
-                              : const SizedBox(),
+                        Container(
+                          height: _theme(context).buttonBarHeight,
+                          margin: _theme(context).topButtonBarMargin,
                         ),
                         Expanded(
-                          child: _mountSeekForwardButton
-                              ? TweenAnimationBuilder<double>(
-                                  tween: Tween<double>(
-                                    begin: 0.0,
-                                    end: _hideSeekForwardButton ? 0.0 : 1.0,
-                                  ),
-                                  duration: const Duration(milliseconds: 200),
-                                  builder: (context, value, child) => Opacity(
+                          child: Center(
+                            child: TweenAnimationBuilder<double>(
+                              tween: Tween<double>(
+                                begin: 0.0,
+                                end: buffering ? 1.0 : 0.0,
+                              ),
+                              duration:
+                                  _theme(context).controlsTransitionDuration,
+                              builder: (context, value, child) {
+                                // Only mount the buffering indicator if the opacity is greater than 0.0.
+                                // This has been done to prevent redundant resource usage in [CircularProgressIndicator].
+                                if (value > 0.0) {
+                                  return Opacity(
                                     opacity: value,
-                                    child: child,
-                                  ),
-                                  onEnd: () {
-                                    if (_hideSeekForwardButton) {
-                                      setState(() {
-                                        _hideSeekForwardButton = false;
-                                        _mountSeekForwardButton = false;
-                                      });
-                                    }
-                                  },
-                                  child: _ForwardSeekIndicator(
-                                    onChanged: (value) {
-                                      _seekBarDeltaValueNotifier.value = value;
-                                    },
-                                    onSubmitted: (value) {
-                                      setState(() {
-                                        _hideSeekForwardButton = true;
-                                      });
-                                      var result = controller(context)
-                                              .player
-                                              .state
-                                              .position +
-                                          value;
-                                      result = result.clamp(
-                                        Duration.zero,
-                                        controller(context)
-                                            .player
-                                            .state
-                                            .duration,
-                                      );
-                                      controller(context).player.seek(result);
-                                    },
-                                  ),
-                                )
-                              : const SizedBox(),
+                                    child: _theme(context)
+                                            .bufferingIndicatorBuilder
+                                            ?.call(context) ??
+                                        child!,
+                                  );
+                                }
+                                return const SizedBox.shrink();
+                              },
+                              child: const CircularProgressIndicator(
+                                color: Color(0xFFFFFFFF),
+                              ),
+                            ),
+                          ),
+                        ),
+                        Container(
+                          height: _theme(context).buttonBarHeight,
+                          margin: _theme(context).bottomButtonBarMargin,
                         ),
                       ],
                     ),
                   ),
-            ],
+                ),
+                // Volume Indicator.
+                IgnorePointer(
+                  child: AnimatedOpacity(
+                    curve: Curves.easeInOut,
+                    opacity: (!mount ||
+                                _theme(context)
+                                    .gesturesEnabledWhileControlsVisible) &&
+                            _volumeIndicator
+                        ? 1.0
+                        : 0.0,
+                    duration: _theme(context).controlsTransitionDuration,
+                    child: _theme(context)
+                            .volumeIndicatorBuilder
+                            ?.call(context, _volumeValue) ??
+                        Container(
+                          alignment: Alignment.center,
+                          decoration: BoxDecoration(
+                            color: const Color(0x88000000),
+                            borderRadius: BorderRadius.circular(64.0),
+                          ),
+                          height: 52.0,
+                          width: 108.0,
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Container(
+                                height: 52.0,
+                                width: 42.0,
+                                alignment: Alignment.centerRight,
+                                child: Icon(
+                                  _volumeValue == 0.0
+                                      ? Icons.volume_off
+                                      : _volumeValue < 0.5
+                                          ? Icons.volume_down
+                                          : Icons.volume_up,
+                                  color: const Color(0xFFFFFFFF),
+                                  size: 24.0,
+                                ),
+                              ),
+                              const SizedBox(width: 8.0),
+                              Expanded(
+                                child: Text(
+                                  '${(_volumeValue * 100.0).round()}%',
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(
+                                    fontSize: 14.0,
+                                    color: Color(0xFFFFFFFF),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 16.0),
+                            ],
+                          ),
+                        ),
+                  ),
+                ),
+                // Brightness Indicator.
+                IgnorePointer(
+                  child: AnimatedOpacity(
+                    curve: Curves.easeInOut,
+                    opacity: (!mount ||
+                                _theme(context)
+                                    .gesturesEnabledWhileControlsVisible) &&
+                            _brightnessIndicator
+                        ? 1.0
+                        : 0.0,
+                    duration: _theme(context).controlsTransitionDuration,
+                    child: _theme(context)
+                            .brightnessIndicatorBuilder
+                            ?.call(context, _volumeValue) ??
+                        Container(
+                          alignment: Alignment.center,
+                          decoration: BoxDecoration(
+                            color: const Color(0x88000000),
+                            borderRadius: BorderRadius.circular(64.0),
+                          ),
+                          height: 52.0,
+                          width: 108.0,
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Container(
+                                height: 52.0,
+                                width: 42.0,
+                                alignment: Alignment.centerRight,
+                                child: Icon(
+                                  _brightnessValue < 1.0 / 3.0
+                                      ? Icons.brightness_low
+                                      : _brightnessValue < 2.0 / 3.0
+                                          ? Icons.brightness_medium
+                                          : Icons.brightness_high,
+                                  color: const Color(0xFFFFFFFF),
+                                  size: 24.0,
+                                ),
+                              ),
+                              const SizedBox(width: 8.0),
+                              Expanded(
+                                child: Text(
+                                  '${(_brightnessValue * 100.0).round()}%',
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(
+                                    fontSize: 14.0,
+                                    color: Color(0xFFFFFFFF),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 16.0),
+                            ],
+                          ),
+                        ),
+                  ),
+                ),
+                // Speedup Indicator.
+                IgnorePointer(
+                  child: Padding(
+                    padding: _theme(context).padding ??
+                        (
+                            // Add padding in fullscreen!
+                            isFullscreen(context)
+                                ? MediaQuery.of(context).padding
+                                : EdgeInsets.zero),
+                    child: Column(
+                      children: [
+                        Container(
+                          height: _theme(context).buttonBarHeight,
+                          margin: _theme(context).topButtonBarMargin,
+                        ),
+                        Expanded(
+                          child: AnimatedOpacity(
+                            duration:
+                                _theme(context).controlsTransitionDuration,
+                            opacity: _speedUpIndicator ? 1 : 0,
+                            child: _theme(context)
+                                    .speedUpIndicatorBuilder
+                                    ?.call(context,
+                                        _theme(context).speedUpFactor) ??
+                                Container(
+                                  alignment: Alignment.topCenter,
+                                  child: Container(
+                                    margin: const EdgeInsets.all(16.0),
+                                    alignment: Alignment.center,
+                                    decoration: BoxDecoration(
+                                      color: const Color(0x88000000),
+                                      borderRadius: BorderRadius.circular(64.0),
+                                    ),
+                                    height: 48.0,
+                                    width: 108.0,
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.center,
+                                      children: [
+                                        const SizedBox(width: 16.0),
+                                        Expanded(
+                                          child: Text(
+                                            '${_theme(context).speedUpFactor.toStringAsFixed(1)}x',
+                                            textAlign: TextAlign.center,
+                                            style: const TextStyle(
+                                              fontSize: 14.0,
+                                              color: Color(0xFFFFFFFF),
+                                            ),
+                                          ),
+                                        ),
+                                        Container(
+                                          height: 48.0,
+                                          width: 48.0 - 16.0,
+                                          alignment: Alignment.centerRight,
+                                          child: const Icon(
+                                            Icons.fast_forward,
+                                            color: Color(0xFFFFFFFF),
+                                            size: 24.0,
+                                          ),
+                                        ),
+                                        const SizedBox(width: 16.0),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                          ),
+                        ),
+                        Container(
+                          height: _theme(context).buttonBarHeight,
+                          margin: _theme(context).bottomButtonBarMargin,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                // Seek Indicator.
+                IgnorePointer(
+                  child: AnimatedOpacity(
+                    duration: _theme(context).controlsTransitionDuration,
+                    opacity: showSwipeDuration ? 1 : 0,
+                    child: _theme(context)
+                            .seekIndicatorBuilder
+                            ?.call(context, Duration(seconds: swipeDuration)) ??
+                        Container(
+                          alignment: Alignment.center,
+                          decoration: BoxDecoration(
+                            color: const Color(0x88000000),
+                            borderRadius: BorderRadius.circular(64.0),
+                          ),
+                          height: 52.0,
+                          width: 108.0,
+                          child: Text(
+                            swipeDuration > 0
+                                ? "+ ${Duration(seconds: swipeDuration).label()}"
+                                : "- ${Duration(seconds: swipeDuration).label()}",
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              fontSize: 14.0,
+                              color: Color(0xFFFFFFFF),
+                            ),
+                          ),
+                        ),
+                  ),
+                ),
+
+                // Double-Tap Seek Button(s):
+                if (!mount || seekOnDoubleTapEnabledWhileControlsAreVisible)
+                  if (_mountSeekBackwardButton || _mountSeekForwardButton)
+                    Positioned.fill(
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: _mountSeekBackwardButton
+                                ? TweenAnimationBuilder<double>(
+                                    tween: Tween<double>(
+                                      begin: 0.0,
+                                      end: _hideSeekBackwardButton ? 0.0 : 1.0,
+                                    ),
+                                    duration: const Duration(milliseconds: 200),
+                                    builder: (context, value, child) => Opacity(
+                                      opacity: value,
+                                      child: child,
+                                    ),
+                                    onEnd: () {
+                                      if (_hideSeekBackwardButton) {
+                                        setState(() {
+                                          _hideSeekBackwardButton = false;
+                                          _mountSeekBackwardButton = false;
+                                        });
+                                      }
+                                    },
+                                    child: _BackwardSeekIndicator(
+                                      onChanged: (value) {
+                                        _seekBarDeltaValueNotifier.value =
+                                            -value;
+                                      },
+                                      onSubmitted: (value) {
+                                        setState(() {
+                                          _hideSeekBackwardButton = true;
+                                        });
+                                        var result = controller(context)
+                                                .player
+                                                .state
+                                                .position -
+                                            value;
+                                        result = result.clamp(
+                                          Duration.zero,
+                                          controller(context)
+                                              .player
+                                              .state
+                                              .duration,
+                                        );
+                                        controller(context).player.seek(result);
+                                      },
+                                    ),
+                                  )
+                                : const SizedBox(),
+                          ),
+                          Expanded(
+                            child: _mountSeekForwardButton
+                                ? TweenAnimationBuilder<double>(
+                                    tween: Tween<double>(
+                                      begin: 0.0,
+                                      end: _hideSeekForwardButton ? 0.0 : 1.0,
+                                    ),
+                                    duration: const Duration(milliseconds: 200),
+                                    builder: (context, value, child) => Opacity(
+                                      opacity: value,
+                                      child: child,
+                                    ),
+                                    onEnd: () {
+                                      if (_hideSeekForwardButton) {
+                                        setState(() {
+                                          _hideSeekForwardButton = false;
+                                          _mountSeekForwardButton = false;
+                                        });
+                                      }
+                                    },
+                                    child: _ForwardSeekIndicator(
+                                      onChanged: (value) {
+                                        _seekBarDeltaValueNotifier.value =
+                                            value;
+                                      },
+                                      onSubmitted: (value) {
+                                        setState(() {
+                                          _hideSeekForwardButton = true;
+                                        });
+                                        var result = controller(context)
+                                                .player
+                                                .state
+                                                .position +
+                                            value;
+                                        result = result.clamp(
+                                          Duration.zero,
+                                          controller(context)
+                                              .player
+                                              .state
+                                              .duration,
+                                        );
+                                        controller(context).player.seek(result);
+                                      },
+                                    ),
+                                  )
+                                : const SizedBox(),
+                          ),
+                        ],
+                      ),
+                    ),
+              ],
+            ),
           ),
-        ),
-      ),
+        );
+      }),
     );
   }
 }

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -143,7 +143,11 @@ class MaterialVideoControlsThemeData {
 
   /// Defines widget's width proportions for double tap actions: `[left seek, instant tap, forward seek]`.
   /// Each integer represents segment width ratio. Default `[1, 1, 1]` means equal segments.
-  final List<int> seekOnDoubleTapLayoutRatios;
+  final List<int> seekOnDoubleTapLayoutTapsRatios;
+
+  /// Defines widget's width proportions for double tap actions: `[left seek, instant tap, forward seek]`.
+  /// Each integer represents segment width ratio. Default `[1, 1, 1]` means equal segments.
+  final List<int> seekOnDoubleTapLayoutWidgetRatios;
 
   /// Whether the controls are initially visible.
   final bool visibleOnMount;
@@ -265,7 +269,8 @@ class MaterialVideoControlsThemeData {
     this.gesturesEnabledWhileControlsVisible = true,
     this.seekOnDoubleTap = false,
     this.seekOnDoubleTapEnabledWhileControlsVisible = true,
-    this.seekOnDoubleTapLayoutRatios = const [1, 1, 1],
+    this.seekOnDoubleTapLayoutTapsRatios = const [1, 1, 1],
+    this.seekOnDoubleTapLayoutWidgetRatios = const [1, 1, 1],
     this.visibleOnMount = false,
     this.speedUpOnLongPress = false,
     this.speedUpFactor = 2.0,
@@ -323,7 +328,8 @@ class MaterialVideoControlsThemeData {
     bool? gesturesEnabledWhileControlsVisible,
     bool? seekOnDoubleTap,
     bool? seekOnDoubleTapEnabledWhileControlsVisible,
-    List<int>? seekOnDoubleTapLayoutRatios,
+    List<int>? seekOnDoubleTapLayoutTapsRatios,
+    List<int>? seekOnDoubleTapLayoutWidgetRatios,
     bool? visibleOnMount,
     bool? speedUpOnLongPress,
     double? speedUpFactor,
@@ -373,8 +379,10 @@ class MaterialVideoControlsThemeData {
       seekOnDoubleTapEnabledWhileControlsVisible:
           seekOnDoubleTapEnabledWhileControlsVisible ??
               this.seekOnDoubleTapEnabledWhileControlsVisible,
-      seekOnDoubleTapLayoutRatios:
-          seekOnDoubleTapLayoutRatios ?? this.seekOnDoubleTapLayoutRatios,
+      seekOnDoubleTapLayoutTapsRatios: seekOnDoubleTapLayoutTapsRatios ??
+          this.seekOnDoubleTapLayoutTapsRatios,
+      seekOnDoubleTapLayoutWidgetRatios: seekOnDoubleTapLayoutWidgetRatios ??
+          this.seekOnDoubleTapLayoutWidgetRatios,
       visibleOnMount: visibleOnMount ?? this.visibleOnMount,
       speedUpOnLongPress: speedUpOnLongPress ?? this.speedUpOnLongPress,
       speedUpFactor: speedUpFactor ?? this.speedUpFactor,
@@ -692,8 +700,10 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
   }
 
   bool _isInSegment(double localX, int segmentIndex) {
+    assert(_theme(context).seekOnDoubleTapLayoutTapsRatios.length == 3,
+        "The number of seekOnDoubleTapLayoutRatios must be 3, i.e. [1, 1, 1]");
     // Local variable with the list of ratios
-    List<int> segmentRatios = _theme(context).seekOnDoubleTapLayoutRatios;
+    List<int> segmentRatios = _theme(context).seekOnDoubleTapLayoutTapsRatios;
 
     int totalRatios = segmentRatios.reduce((a, b) => a + b);
 
@@ -1355,7 +1365,8 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                       child: Row(
                         children: [
                           Expanded(
-                            flex: 2,
+                            flex: _theme(context)
+                                .seekOnDoubleTapLayoutWidgetRatios[0],
                             child: _mountSeekBackwardButton
                                 ? TweenAnimationBuilder<double>(
                                     tween: Tween<double>(
@@ -1403,9 +1414,13 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                 : const SizedBox(),
                           ),
                           //Area in the middle where the double-tap seek buttons are ignored in
-                          const Expanded(child: SizedBox()),
+                          if (_theme(context)
+                                  .seekOnDoubleTapLayoutWidgetRatios[1] >
+                              0)
+                            const Expanded(child: SizedBox()),
                           Expanded(
-                            flex: 2,
+                            flex: _theme(context)
+                                .seekOnDoubleTapLayoutWidgetRatios[2],
                             child: _mountSeekForwardButton
                                 ? TweenAnimationBuilder<double>(
                                     tween: Tween<double>(

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -141,6 +141,10 @@ class MaterialVideoControlsThemeData {
   /// NOTE: This option is ignored when [seekOnDoubleTap] is false.
   final bool seekOnDoubleTapEnabledWhileControlsVisible;
 
+  /// Defines widget's width proportions for double tap actions: `[left seek, instant tap, forward seek]`.
+  /// Each integer represents segment width ratio. Default `[1, 1, 1]` means equal segments.
+  final List<int> seekOnDoubleTapLayoutRatios;
+
   /// Whether the controls are initially visible.
   final bool visibleOnMount;
 
@@ -261,6 +265,7 @@ class MaterialVideoControlsThemeData {
     this.gesturesEnabledWhileControlsVisible = true,
     this.seekOnDoubleTap = false,
     this.seekOnDoubleTapEnabledWhileControlsVisible = true,
+    this.seekOnDoubleTapLayoutRatios = const [1, 1, 1],
     this.visibleOnMount = false,
     this.speedUpOnLongPress = false,
     this.speedUpFactor = 2.0,
@@ -318,6 +323,7 @@ class MaterialVideoControlsThemeData {
     bool? gesturesEnabledWhileControlsVisible,
     bool? seekOnDoubleTap,
     bool? seekOnDoubleTapEnabledWhileControlsVisible,
+    List<int>? seekOnDoubleTapLayoutRatios,
     bool? visibleOnMount,
     bool? speedUpOnLongPress,
     double? speedUpFactor,
@@ -367,6 +373,8 @@ class MaterialVideoControlsThemeData {
       seekOnDoubleTapEnabledWhileControlsVisible:
           seekOnDoubleTapEnabledWhileControlsVisible ??
               this.seekOnDoubleTapEnabledWhileControlsVisible,
+      seekOnDoubleTapLayoutRatios:
+          seekOnDoubleTapLayoutRatios ?? this.seekOnDoubleTapLayoutRatios,
       visibleOnMount: visibleOnMount ?? this.visibleOnMount,
       speedUpOnLongPress: speedUpOnLongPress ?? this.speedUpOnLongPress,
       speedUpFactor: speedUpFactor ?? this.speedUpFactor,
@@ -684,24 +692,29 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
   }
 
   bool _isInSegment(double localX, int segmentIndex) {
-    double segmentWidth = _widgetWidth / 5; // Split into [2, 1, 2] segments
-    double start, end;
+    // Local variable with the list of ratios
+    List<int> segmentRatios = _theme(context).seekOnDoubleTapLayoutRatios;
 
-    if (segmentIndex == 0) {
-      start = 0;
-      end = 2 * segmentWidth;
-    } else if (segmentIndex == 1) {
-      start = 2 * segmentWidth;
-      end = 3 * segmentWidth;
-    } else if (segmentIndex == 2) {
-      start = 3 * segmentWidth;
-      end = _widgetWidth;
-    } else {
-      // Handle an invalid segmentIndex gracefully
-      return false;
+    int totalRatios = segmentRatios.reduce((a, b) => a + b);
+
+    double segmentWidthMultiplier = _widgetWidth / totalRatios;
+    double start = 0;
+    double end;
+
+    for (int i = 0; i < segmentRatios.length; i++) {
+      end = start + (segmentWidthMultiplier * segmentRatios[i]);
+
+      // Check if the current index matches the segmentIndex and if localX falls within it
+      if (i == segmentIndex && localX >= start && localX <= end) {
+        return true;
+      }
+
+      // Set the start of the next segment
+      start = end;
     }
 
-    return localX >= start && localX <= end;
+    // If localX does not fall within the specified segment
+    return false;
   }
 
   bool _isInRightSegment(double localX) {
@@ -1347,9 +1360,7 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                 ? TweenAnimationBuilder<double>(
                                     tween: Tween<double>(
                                       begin: 0.0,
-                                      end: _hideSeekBackwardButton
-                                          ? 0.0
-                                          : 1.0,
+                                      end: _hideSeekBackwardButton ? 0.0 : 1.0,
                                     ),
                                     duration: const Duration(milliseconds: 200),
                                     builder: (context, value, child) => Opacity(
@@ -1399,9 +1410,7 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                 ? TweenAnimationBuilder<double>(
                                     tween: Tween<double>(
                                       begin: 0.0,
-                                      end: _hideSeekForwardButton
-                                          ? 0.0
-                                          : 1.0,
+                                      end: _hideSeekForwardButton ? 0.0 : 1.0,
                                     ),
                                     duration: const Duration(milliseconds: 200),
                                     builder: (context, value, child) => Opacity(

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -700,8 +700,6 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
   }
 
   bool _isInSegment(double localX, int segmentIndex) {
-    assert(_theme(context).seekOnDoubleTapLayoutTapsRatios.length == 3,
-        "The number of seekOnDoubleTapLayoutRatios must be 3, i.e. [1, 1, 1]");
     // Local variable with the list of ratios
     List<int> segmentRatios = _theme(context).seekOnDoubleTapLayoutTapsRatios;
 
@@ -839,6 +837,10 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
     var seekOnDoubleTapEnabledWhileControlsAreVisible =
         (_theme(context).seekOnDoubleTap &&
             _theme(context).seekOnDoubleTapEnabledWhileControlsVisible);
+    assert(_theme(context).seekOnDoubleTapLayoutTapsRatios.length == 3,
+        "The number of seekOnDoubleTapLayoutTapsRatios must be 3, i.e. [1, 1, 1]");
+    assert(_theme(context).seekOnDoubleTapLayoutWidgetRatios.length == 3,
+        "The number of seekOnDoubleTapLayoutWidgetRatios must be 3, i.e. [1, 1, 1]");
     return Theme(
       data: Theme.of(context).copyWith(
         focusColor: const Color(0x00000000),

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -722,7 +722,6 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
     }
 
     onTap();
-    print("_handlePointerDown onTap");
   }
 
   void _handleTapDown(TapDownDetails details) {
@@ -731,7 +730,6 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
     }
 
     onTap();
-    print("_handleTapDown onTap");
   }
 
   @override
@@ -874,7 +872,6 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                           onPointerDown: (event) => _handlePointerDown(event),
                           child: GestureDetector(
                             onTapDown: (details) => _handleTapDown(details),
-                            // onTap: onTap,
                             onDoubleTapDown: _handleDoubleTapDown,
                             onLongPress: _theme(context).speedUpOnLongPress
                                 ? _handleLongPress

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -1430,7 +1430,10 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                           if (_theme(context)
                                   .seekOnDoubleTapLayoutWidgetRatios[1] >
                               0)
-                            const Expanded(child: SizedBox()),
+                            Expanded(
+                                flex: _theme(context)
+                                    .seekOnDoubleTapLayoutWidgetRatios[1],
+                                child: const SizedBox()),
                           Expanded(
                             flex: _theme(context)
                                 .seekOnDoubleTapLayoutWidgetRatios[2],


### PR DESCRIPTION


#### Problem and Fix Summary
1. **Widget Width Handling Issue**:
   - **Problem**: Previously, the width for video controls was derived from the MediaQuery, which captures the entire screen width. This approach caused issues when the video player wasn't in full-screen mode, leading to improper control scaling and misalignment.
   - **Fix**: Introduced the use of `LayoutBuilder` to dynamically obtain the width of the widget itself rather than the entire screen. This ensures that the controls are correctly sized and positioned regardless of the player's on-screen size, enhancing the adaptability of the video player in different layouts.

2. **Gesture Detection Delay**:
   - **Problem**: The original implementation used a gesture detector that had a delay while determining whether the user's action was a single or double tap. This delay hindered immediate responsiveness, particularly in showing controls.
   - **Fix**: Implemented segmented logic and a listener to immediately catch touch events. If a touch is detected in the central area of the video player, the controls are shown instantly, similar to YouTube's approach.

3. **Double Tap Seek UI Adjustment Summary**:
    - **Problem**: Previously, the double-tap-to-seek function covered the entire width of the video player, leading to confusion as it overlapped with areas for normal interactions.
    - **Fix**: Implemented a segmented layout, dividing the player's width into a [2,1,2] ratio. The double-tap-to-seek feature is now positioned on the sides (the '2' segments), with the central segment ('1') dedicated to regular taps. This design, similar to YouTube's user interface, allows clear differentiation between areas for normal taps and double-tap-to-seek, reducing user confusion and improving the video player's intuitiveness.
