### PR TITLE
libass fix not  displayed on Android

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2460,8 +2460,8 @@ class NativePlayer extends PlatformPlayer {
             // Use it if located inside the application bundle, otherwise no worries.
             options.addAll(
               {
-                'config': 'yes',
-                'config-dir': directory,
+                'sub-fonts-dir': directory,
+                'sub-font': configuration.libassAndroidFontFamilyName.toString(),
               },
             );
             print(subfont);

--- a/media_kit/lib/src/player/platform_player.dart
+++ b/media_kit/lib/src/player/platform_player.dart
@@ -6,20 +6,20 @@
 
 import 'dart:async';
 import 'dart:typed_data';
-import 'package:meta/meta.dart';
-import 'package:collection/collection.dart';
 
-import 'package:media_kit/src/models/track.dart';
-import 'package:media_kit/src/models/playable.dart';
-import 'package:media_kit/src/models/playlist.dart';
-import 'package:media_kit/src/models/player_log.dart';
-import 'package:media_kit/src/models/media/media.dart';
+import 'package:collection/collection.dart';
 import 'package:media_kit/src/models/audio_device.dart';
 import 'package:media_kit/src/models/audio_params.dart';
-import 'package:media_kit/src/models/video_params.dart';
+import 'package:media_kit/src/models/media/media.dart';
+import 'package:media_kit/src/models/playable.dart';
+import 'package:media_kit/src/models/player_log.dart';
 import 'package:media_kit/src/models/player_state.dart';
-import 'package:media_kit/src/models/playlist_mode.dart';
 import 'package:media_kit/src/models/player_stream.dart';
+import 'package:media_kit/src/models/playlist.dart';
+import 'package:media_kit/src/models/playlist_mode.dart';
+import 'package:media_kit/src/models/track.dart';
+import 'package:media_kit/src/models/video_params.dart';
+import 'package:meta/meta.dart';
 
 /// {@template platform_player}
 /// PlatformPlayer
@@ -463,12 +463,17 @@ class PlayerConfiguration {
   /// By default, subtitles rendering is Flutter `Widget` based.
   ///
   /// On Android, this option requires [libassAndroidFont] to be set.
+  ///
+  /// On Android, this option requires [libassAndroidFontFamilyName] to be set.
   final bool libass;
 
   /// Asset name of the `.ttf` font file to be used for [libass](https://github.com/libass/libass) based subtitle rendering on Android.
   ///
   /// e.g. `assets/fonts/subtitle.ttf`
   final String? libassAndroidFont;
+
+  /// e.g. the name of `subtitle.ttf` displayed in the system is the font name, not the file name!
+  final String? libassAndroidFontFamilyName;
 
   /// Sets the log level on native backend.
   /// Default: `none`.
@@ -496,6 +501,7 @@ class PlayerConfiguration {
     this.muted = false,
     this.libass = false,
     this.libassAndroidFont,
+    this.libassAndroidFontFamilyName,
     this.logLevel = MPVLogLevel.error,
     this.bufferSize = 32 * 1024 * 1024,
     this.protocolWhitelist = const [

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -5,14 +5,14 @@
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
 // ignore_for_file: non_constant_identifier_names
 import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:media_kit_video/media_kit_video.dart';
-import 'package:volume_controller/volume_controller.dart';
-import 'package:screen_brightness/screen_brightness.dart';
-
-import 'package:media_kit_video/media_kit_video_controls/src/controls/methods/video_state.dart';
 import 'package:media_kit_video/media_kit_video_controls/src/controls/extensions/duration.dart';
+import 'package:media_kit_video/media_kit_video_controls/src/controls/methods/video_state.dart';
 import 'package:media_kit_video/media_kit_video_controls/src/controls/widgets/video_controls_theme_data_injector.dart';
+import 'package:screen_brightness/screen_brightness.dart';
+import 'package:volume_controller/volume_controller.dart';
 
 /// {@template material_video_controls}
 ///
@@ -825,18 +825,8 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                             ? _handleLongPressEnd
                             : null,
                         onDoubleTap: () {
-                          if (_tapPosition != null &&
-                              _tapPosition!.dx >
-                                  MediaQuery.of(context).size.width / 2) {
-                            if ((!mount && _theme(context).seekOnDoubleTap) ||
-                                seekOnDoubleTapEnabledWhileControlsAreVisible) {
-                              onDoubleTapSeekForward();
-                            }
-                          } else {
-                            if ((!mount && _theme(context).seekOnDoubleTap) ||
-                                seekOnDoubleTapEnabledWhileControlsAreVisible) {
-                              onDoubleTapSeekBackward();
-                            }
+                          if (!mount && _theme(context).seekOnDoubleTap) {
+                            controller(context).player.playOrPause();
                           }
                         },
                         onHorizontalDragUpdate: (details) {


### PR DESCRIPTION
It took me a long time to find the reason why srt and ass subtitles are occasionally displayed and sometimes not displayed. This update allows subtitles to be loaded in the default font. If more fonts are used, fonts.conf is required.

Reference link
https://mpv.io/manual/master/#options-sub-fonts-dir