### PR TITLE
Update `js` package in `pubspec.yaml`

### DIFF
--- a/media_kit/pubspec.yaml
+++ b/media_kit/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   http: ">=0.13.0 <2.0.0"
   safe_local_storage: ^1.0.2
   universal_platform: ^1.0.0+1
-  js: ^0.6.7
+  js: ^0.7.0
 
 dev_dependencies:
   test: ^1.24.1


### PR DESCRIPTION
Package `js` has a new version which was released about 2 weeks ago.

Other dependencies that are using the latest `js` package has gotten incompatible with `media_kit`, because the current `^0.6.7.` does not work with `^0.7.0`.

Below is the output from `flutter pub get` of an app called `mangayomi`.

```
Because media_kit 1.1.10+1 depends on js ^0.6.7 and no versions of media_kit match >1.1.10+1 <2.0.0,
  media_kit ^1.1.10+1 requires js ^0.6.7.
And because rinf >=6.0.0 depends on js ^0.7.0, media_kit ^1.1.10+1 is incompatible with rinf >=6.0.0.
So, because mangayomi depends on both media_kit ^1.1.10+1 and rinf ^6.0.0, version solving failed.
```