### PR TITLE
fix: Don't use padding in screenshot pixels as the alpha channel

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2846,7 +2846,7 @@ Uint8List? _screenshot(_ScreenshotData data) {
             final pixels = Image(
               width: w,
               height: h,
-              numChannels: 4,
+              numChannels: 3,
             );
             for (final pixel in pixels) {
               final x = pixel.x;
@@ -2855,7 +2855,6 @@ Uint8List? _screenshot(_ScreenshotData data) {
               pixel.b = bytes[i];
               pixel.g = bytes[i + 1];
               pixel.r = bytes[i + 2];
-              pixel.a = bytes[i + 3];
             }
             image = encodeJpg(pixels);
             break;
@@ -2865,7 +2864,7 @@ Uint8List? _screenshot(_ScreenshotData data) {
             final pixels = Image(
               width: w,
               height: h,
-              numChannels: 4,
+              numChannels: 3,
             );
             for (final pixel in pixels) {
               final x = pixel.x;
@@ -2874,7 +2873,6 @@ Uint8List? _screenshot(_ScreenshotData data) {
               pixel.b = bytes[i];
               pixel.g = bytes[i + 1];
               pixel.r = bytes[i + 2];
-              pixel.a = bytes[i + 3];
             }
             image = encodePng(pixels);
             break;


### PR DESCRIPTION
The screenshot code treats the input format as B8G8R8A8, but the final "channel" is actually just padding data, as per the `screenshot-raw` docs (https://mpv.io/manual/stable/#command-interface-screenshot-raw):

> This format is organized as B8G8R8X8 [...]. The contents of the
> padding X are undefined.

Using this as the alpha results in garbage, which can manifest as fully-blank images if it's all 0s. (This doesn't appear to have affected JPEGs, since the format has no alpha channel, but it does sometimes affect PNGs.)