### PR TITLE
fix: Use a Scaffold as the outermost widget on fullscreen video pages

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart
@@ -27,8 +27,8 @@ Future<void> enterFullscreen(BuildContext context) {
         final controllerValue = controller(context);
         Navigator.of(context, rootNavigator: true).push(
           PageRouteBuilder(
-            pageBuilder: (_, __, ___) => Material(
-              child: VideoControlsThemeDataInjector(
+            pageBuilder: (_, __, ___) => Scaffold(
+              body: VideoControlsThemeDataInjector(
                 // NOTE: Make various *VideoControlsThemeData from the parent context available in the fullscreen context.
                 context: context,
                 child: VideoStateInheritedWidget(


### PR DESCRIPTION
Using a plain Material means that functionality that's tied to the nearest Scaffold, suck as SnackBars, won't actually be displayed on the page.