### PR TITLE
feat: Add support for including libass subtitles in screenshots

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -1333,9 +1333,14 @@ class NativePlayer extends PlatformPlayer {
   /// * `image/jpeg`: Returns a JPEG encoded image.
   /// * `image/png`: Returns a PNG encoded image.
   /// * `null`: Returns BGRA pixel buffer.
+  ///
+  /// If [includeLibassSubtitles] is `true` *and* [PlayerConfiguration.libass] is `true`, then the
+  /// screenshot will include the on-screen subtitles.
   @override
   Future<Uint8List?> screenshot(
-      {String? format = 'image/jpeg', bool synchronized = true}) async {
+      {String? format = 'image/jpeg',
+      bool synchronized = true,
+      bool includeLibassSubtitles = false}) async {
     Future<Uint8List?> function() async {
       if (![
         'image/jpeg',
@@ -1361,6 +1366,7 @@ class NativePlayer extends PlatformPlayer {
           ctx.address,
           NativeLibrary.path,
           format,
+          includeLibassSubtitles,
         ),
       );
     }
@@ -2766,11 +2772,13 @@ class _ScreenshotData {
   final int ctx;
   final String lib;
   final String? format;
+  final bool includeLibassSubtitles;
 
   const _ScreenshotData(
     this.ctx,
     this.lib,
     this.format,
+    this.includeLibassSubtitles,
   );
 }
 
@@ -2786,7 +2794,7 @@ Uint8List? _screenshot(_ScreenshotData data) {
   // https://mpv.io/manual/stable/#command-interface-screenshot-raw
   final args = [
     'screenshot-raw',
-    'video',
+    data.includeLibassSubtitles ? 'subtitles' : 'video',
   ];
 
   final result = calloc<generated.mpv_node>();

--- a/media_kit/lib/src/player/platform_player.dart
+++ b/media_kit/lib/src/player/platform_player.dart
@@ -279,7 +279,9 @@ abstract class PlatformPlayer {
     );
   }
 
-  Future<Uint8List?> screenshot({String? format = 'image/jpeg'}) async {
+  Future<Uint8List?> screenshot(
+      {String? format = 'image/jpeg',
+      bool includeLibassSubtitles = false}) async {
     throw UnimplementedError(
       '[PlatformPlayer.screenshot] is not implemented',
     );

--- a/media_kit/lib/src/player/player.dart
+++ b/media_kit/lib/src/player/player.dart
@@ -311,9 +311,16 @@ class Player {
   /// * `image/jpeg`: Returns a JPEG encoded image.
   /// * `image/png`: Returns a PNG encoded image.
   /// * `null`: Returns BGRA pixel buffer.
-  Future<Uint8List?> screenshot({String? format = 'image/jpeg'}) async {
+  ///
+  /// On the native backend, if [includeLibassSubtitles] is `true` *and*
+  /// [PlayerConfiguration.libass] is `true`, then the screenshot will include
+  /// the on-screen subtitles. This option is ignored by the web backend.
+  Future<Uint8List?> screenshot(
+      {String? format = 'image/jpeg',
+      bool includeLibassSubtitles = false}) async {
     return platform?.screenshot(
       format: format,
+      includeLibassSubtitles: includeLibassSubtitles,
     );
   }
 

--- a/media_kit/lib/src/player/web/player/real.dart
+++ b/media_kit/lib/src/player/web/player/real.dart
@@ -1359,9 +1359,13 @@ class WebPlayer extends PlatformPlayer {
   /// The [format] parameter specifies the format of the image to be returned. Supported values are:
   /// * `image/jpeg`
   /// * `image/png`
+  ///
+  /// [includeLibassSubtitles] is ignored.
   @override
   Future<Uint8List?> screenshot(
-      {String? format = 'image/jpeg', bool synchronized = true}) async {
+      {String? format = 'image/jpeg',
+      bool synchronized = true,
+      bool includeLibassSubtitles = false}) async {
     Future<Uint8List?> function() async {
       if (![
         'image/jpeg',


### PR DESCRIPTION
On the native backend, this is essentially available for free: we just need to swap the flag given to the `screenshot-raw` command.

This option is simply ignored by the web backend.