### PR TITLE
fix: Seek indicators get stuck as mounted but invisible

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -1296,6 +1296,11 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                   child: _BackwardSeekIndicator(
                                     onChanged: (value) {
                                       _seekBarDeltaValueNotifier.value = -value;
+                                      if (_hideSeekBackwardButton) {
+                                        setState(() {
+                                          _hideSeekBackwardButton = false;
+                                        });
+                                      }
                                     },
                                     onSubmitted: (value) {
                                       setState(() {
@@ -1342,6 +1347,11 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                   child: _ForwardSeekIndicator(
                                     onChanged: (value) {
                                       _seekBarDeltaValueNotifier.value = value;
+                                      if (_hideSeekForwardButton) {
+                                        setState(() {
+                                          _hideSeekForwardButton = false;
+                                        });
+                                      }
                                     },
                                     onSubmitted: (value) {
                                       setState(() {


### PR DESCRIPTION
The usual double-tap-to-seek code flow is:

1. The user double-taps the screen, which sets `_mountSeek[...]Button` to `true` (mounting the indicator and starting its animation) and starts a submission timer.
2. The animation to display the seek indicator ends.
3. The timer calls `onSubmitted`, which sets `_hideSeek[...]Button` to `true`.
4. Next time `build()` runs, `_hideSeek[...]Button` causes the animation to be restarted, now going backwards and hiding the indicator.
5. The animation ends, sees `_hide[...]Button` is `true`, and sets it and `_mountSeek[...]Button` to `false`, completely unmounting the indicator.

However, if between steps 3 and 5, the user double-taps again, a new timer will be started. If that timer then invokes `onSubmitted` *after* step 5, `_hide[...]Button` will be set to `true` while `_mountSeek[...]Button` is `false`. This means that, next time the user double-taps the screen, the animation will be run with a start *and* end point of `0.0`, resulting in `onEnd` never being called to unmount the indicator. Thus, the indicator stays mounted and still responds to touch events, but it's now completely invisible.

In order to fix this, if a double-tap occurs while hiding the indicator, we can just set `_hideSeek[...]Button` back to `false`, essentially re- starting the entire flow. This allows the user to safely interact with the indicator during the entire period that it's visible on-screen.