### PR TITLE
ThemeDeck #15 | Bad filepaths fix for player.add

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -528,12 +528,11 @@ class NativePlayer extends PlatformPlayer {
       current.add(media);
       // ---------------------------------------------
 
-      final command = 'loadfile ${media.uri} append'.toNativeUtf8();
-      mpv.mpv_command_string(
-        ctx,
-        command.cast(),
-      );
-      calloc.free(command.cast());
+      await _command([
+        'loadfile',
+        media.uri,
+        'append',
+      ]);
     }
 
     if (synchronized) {


### PR DESCRIPTION
https://github.com/isaacy13/ThemeDeck/issues/15
- fixed issue where filepaths with bad characters would cause issues
- also addresses security concern with executing arbitrary mpv commands