### PR TITLE
ThemeDeck #20 | Disable MPV cleanup

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -564,6 +564,7 @@ class NativePlayer extends PlatformPlayer {
           [
             PlaylistMode.none,
             PlaylistMode.single,
+            PlaylistMode.loop,
           ].contains(state.playlistMode)) {
         state = state.copyWith(
           // Allow playOrPause /w state.completed code-path to play the playlist again.

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -528,12 +528,11 @@ class NativePlayer extends PlatformPlayer {
       current.add(media);
       // ---------------------------------------------
 
-      final command = 'loadfile ${media.uri} append'.toNativeUtf8();
-      mpv.mpv_command_string(
-        ctx,
-        command.cast(),
-      );
-      calloc.free(command.cast());
+      await _command([
+        'loadfile',
+        media.uri,
+        'append',
+      ]);
     }
 
     if (synchronized) {

--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
@@ -148,20 +148,7 @@ void MediaKitEventLoopHandler::Dispose(int64_t handle, bool clean) {
   std::cout << "MediaKitEventLoopHandler::Dispose: " << handle << std::endl;
 }
 
-void MediaKitEventLoopHandler::Initialize() {
-  auto contexts = std::vector<mpv_handle*>();
-
-  mutex_.lock();
-  for (auto& [context, _] : threads_) {
-    contexts.push_back(context);
-  }
-  mutex_.unlock();
-
-  for (auto& context : contexts) {
-    Dispose(reinterpret_cast<int64_t>(context));
-    mpv_command_string(context, "quit");
-  }
-}
+void MediaKitEventLoopHandler::Initialize() {}
 
 bool MediaKitEventLoopHandler::IsRegistered(int64_t handle) {
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
https://github.com/isaacy13/ThemeDeck/issues/20
- don't cleanup MPV each time instance initializes (so new flutter windows don't invalidate old ones)