### PR TITLE
Fix a bug where `Media#extras` property  is lost when handling updates to `playlist` (`MPV_EVENT_PROPERTY_CHANGE`)

### DIFF
--- a/media_kit/lib/src/models/media/media_native.dart
+++ b/media_kit/lib/src/models/media/media_native.dart
@@ -97,6 +97,11 @@ class Media extends Playable {
   /// Default: `null`.
   final Duration? end;
 
+  /// External audio file.
+  ///
+  /// Default: `null`.
+  final Media? externalAudioFile;
+
   /// Whether instance is instantiated from [Media.memory].
   bool _memory = false;
 
@@ -107,6 +112,7 @@ class Media extends Playable {
     Map<String, String>? httpHeaders,
     this.start,
     this.end,
+    this.externalAudioFile,
   })  : uri = normalizeURI(resource),
         extras = extras ?? cache[normalizeURI(resource)]?.extras,
         httpHeaders =
@@ -199,6 +205,7 @@ class Media extends Playable {
     Map<String, String>? httpHeaders,
     Duration? start,
     Duration? end,
+    Media? externalAudioFile,
   }) {
     return Media(
       uri ?? this.uri,
@@ -206,6 +213,7 @@ class Media extends Playable {
       httpHeaders: httpHeaders ?? this.httpHeaders,
       start: start ?? this.start,
       end: end ?? this.end,
+      externalAudioFile: externalAudioFile ?? this.externalAudioFile,
     );
   }
 

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -1719,7 +1719,11 @@ class NativePlayer extends PlatformPlayer {
               .map(
                 (i, e) => MapEntry(
                   i,
-                  e.copyWith(start: current[i].start, end: current[i].end),
+                  e.copyWith(
+                    start: current[i].start,
+                    end: current[i].end,
+                    extras: current[i].extras,
+                  ),
                 ),
               )
               .values

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -204,13 +204,17 @@ class NativePlayer extends PlatformPlayer {
       // isPlayingStateChangeAllowed = false;
 
       for (int i = 0; i < playlist.length; i++) {
-        await _command(
-          [
-            'loadfile',
-            playlist[i].uri,
-            'append',
-          ],
-        );
+        final List<String> commandArgs = [
+          'loadfile',
+          playlist[i].uri,
+          'append',
+        ];
+
+        if (playlist[i].externalAudioFile != null) {
+          commandArgs.add('audio-file=${playlist[i].externalAudioFile!.uri}');
+        }
+
+        await _command(commandArgs);
       }
 
       // If [play] is `true`, then exit paused state.
@@ -1723,6 +1727,7 @@ class NativePlayer extends PlatformPlayer {
                     start: current[i].start,
                     end: current[i].end,
                     extras: current[i].extras,
+                    externalAudioFile: current[i].externalAudioFile,
                   ),
                 ),
               )


### PR DESCRIPTION
### Steps to reproduce
```dart
// Create a playlist where each media has unique clip_id in extras
final playlist = Playlist([
  Media(
    'file.mp4',
    extras: {'clip_id': 'file.mp4 1'},
    start: Duration.zero,
    end: Duration(seconds: 10),
  ),
  Media(
    'file.mp4',
    extras: {'clip_id': 'file.mp4 2'},
    start: Duration(seconds: 10),
    end: Duration(seconds: 20),
  ),
]);

await player.open(playlist);

for (final media in player.state.playlist.medias) {
  debugPrint('media: ${media.extras}');
}

// Prints:
// media: {clip_id: file.mp4 2}
// media: {clip_id: file.mp4 2}
```

Observe that every instance of `Media` has `extras` of the last media in the playlist.