### PR TITLE
Fix a bug where `Media#extras` property  is lost when handling updates to `playlist` (`MPV_EVENT_PROPERTY_CHANGE`)

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -1719,7 +1719,11 @@ class NativePlayer extends PlatformPlayer {
               .map(
                 (i, e) => MapEntry(
                   i,
-                  e.copyWith(start: current[i].start, end: current[i].end),
+                  e.copyWith(
+                    start: current[i].start,
+                    end: current[i].end,
+                    extras: current[i].extras,
+                  ),
                 ),
               )
               .values


### PR DESCRIPTION
### Steps to reproduce
```dart
// Create a playlist where each media has unique clip_id in extras
final playlist = Playlist([
  Media(
    'file.mp4',
    extras: {'clip_id': 'file.mp4 1'},
    start: Duration.zero,
    end: Duration(seconds: 10),
  ),
  Media(
    'file.mp4',
    extras: {'clip_id': 'file.mp4 2'},
    start: Duration(seconds: 10),
    end: Duration(seconds: 20),
  ),
]);

await player.open(playlist);

for (final media in player.state.playlist.medias) {
  debugPrint('media: ${media.extras}');
}

// Prints:
// media: {clip_id: file.mp4 2}
// media: {clip_id: file.mp4 2}
```

Observe that every instance of `Media` has `extras` of the last media in the playlist.