### PR TITLE
fix: added check for http headers not empty on web

### DIFF
--- a/media_kit/lib/src/models/media/media_web.dart
+++ b/media_kit/lib/src/models/media/media_web.dart
@@ -90,9 +90,11 @@ class Media extends Playable {
         extras = extras ?? cache[normalizeURI(resource)]?.extras,
         httpHeaders =
             httpHeaders ?? cache[normalizeURI(resource)]?.httpHeaders {
-    if (httpHeaders != null || httpHeaders!.isNotEmpty) {
+    // Ensure httpHeaders are not null or empty to prevent using unsupported HTTP headers on the web
+    if (httpHeaders != null && httpHeaders.isNotEmpty) {
       throw UnsupportedError('HTTP headers are not supported on web');
     }
+
     // Increment reference count.
     ref[uri] = ((ref[uri] ?? 0) + 1).clamp(0, 1 << 32);
     // Store [this] instance in [cache].

--- a/media_kit/lib/src/models/media/media_web.dart
+++ b/media_kit/lib/src/models/media/media_web.dart
@@ -90,7 +90,7 @@ class Media extends Playable {
         extras = extras ?? cache[normalizeURI(resource)]?.extras,
         httpHeaders =
             httpHeaders ?? cache[normalizeURI(resource)]?.httpHeaders {
-    if (httpHeaders != null) {
+    if (httpHeaders != null || httpHeaders!.isNotEmpty) {
       throw UnsupportedError('HTTP headers are not supported on web');
     }
     // Increment reference count.


### PR DESCRIPTION

### Description:
This pull request updates the error handling for HTTP headers in the web-specific implementation of our Media class. The adjustment is made to prevent unsupported HTTP header operations on web platforms more effectively.

### Context:
In the current architecture, the `DataSource` class  https://github.com/media-kit/media-kit/blob/dad52462dd56643ba27d4c581bbcff0fce8fbde1/video_player_media_kit/lib/src/media_kit_video_player.dart#L90, defaults to an empty map if no headers are provided. The prior check in our code did not handle this default case, potentially leading to unintended behavior when an empty map is incorrectly treated as a valid input.

### Changes:
I've refined the HTTP header checks to throw an `UnsupportedError` only when `httpHeaders` is not null and contains one or more key-value pairs. This ensures that empty maps, which are the default state in some instances, do not trigger errors, aligning with the typical usage scenarios on web platforms where HTTP headers might be intentionally left unset.

### Impact:
This change will prevent the unnecessary triggering of exceptions for empty HTTP header maps, reducing confusion and aligning error handling with actual unsupported use cases.

