### PR TITLE
improving seek speed

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -765,6 +765,10 @@ class NativePlayer extends PlatformPlayer {
     }
 
     if (synchronized) {
+      if (duration == lastSeekPosition) {
+        return Future.value();
+      }
+      lastSeekPosition = duration;
       return lock.synchronized(function);
     } else {
       return function();
@@ -2696,6 +2700,10 @@ class NativePlayer extends PlatformPlayer {
   ///
   /// This is used to prevent [state.buffering] being set to `true` when [pause] or [playOrPause] is called.
   bool isBufferingStateChangeAllowed = true;
+
+  /// last seek position
+  /// this is used to prevent seeking to the same position twice
+  Duration? lastSeekPosition;
 
   /// Current loaded [Media] queue.
   List<Media> current = <Media>[];


### PR DESCRIPTION
<img width="721" alt="image" src="https://github.com/media-kit/media-kit/assets/25157308/1fc1face-3dda-4f69-adea-75439459ad94">


we were using `absolute` which uses exact and from the docs looks like that is slow, when testing with the new code it seems faster, but i dont feel that the workaround i did to allow such logic is good, 

so this needs further testing and a better/cleaner position logic

# issues i found which needs to be fixed before merging:
- [x] multiple seeks in the same time is not working correctly due to position not being updated 


from my testing for now it should be all good and seeking is faster when called multiple times (that was a problem in general ) 
and seeking is 50% faster from what i feel