### PR TITLE
fix: multiple seeks called on same time

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -769,6 +769,10 @@ class NativePlayer extends PlatformPlayer {
     }
 
     if (synchronized) {
+       if (duration == lastSeekPosition) {
+        return Future.value();
+      }
+      lastSeekPosition = duration;
       return lock.synchronized(function);
     } else {
       return function();
@@ -2701,6 +2705,10 @@ class NativePlayer extends PlatformPlayer {
   /// This is used to prevent [state.buffering] being set to `true` when [pause] or [playOrPause] is called.
   bool isBufferingStateChangeAllowed = true;
 
+ /// last seek position
+  /// this is used to prevent seeking to the same position twice
+  Duration? lastSeekPosition;
+  
   /// Current loaded [Media] queue.
   List<Media> current = <Media>[];
 

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -769,11 +769,18 @@ class NativePlayer extends PlatformPlayer {
     }
 
     if (synchronized) {
-       if (duration == lastSeekPosition) {
+      if (duration == lastSeekPosition) {
         return Future.value();
       }
       lastSeekPosition = duration;
-      return lock.synchronized(function);
+      return lock.synchronized(function)
+        ..then((value) {
+          // this is needed to reset lastSeekPosition
+          // if the user is seeking to the same position after the first seek finished
+          if (duration == lastSeekPosition) {
+            lastSeekPosition = null;
+          }
+        });
     } else {
       return function();
     }
@@ -2706,10 +2713,10 @@ class NativePlayer extends PlatformPlayer {
   /// This is used to prevent [state.buffering] being set to `true` when [pause] or [playOrPause] is called.
   bool isBufferingStateChangeAllowed = true;
 
- /// last seek position
+  /// last seek position
   /// this is used to prevent seeking to the same position twice
   Duration? lastSeekPosition;
-  
+
   /// Current loaded [Media] queue.
   List<Media> current = <Media>[];
 


### PR DESCRIPTION

This fix was originally part of [PR #791](https://github.com/media-kit/media-kit/pull/791) but was separated due to failing tests and the need for additional validation to ensure it works as expected. This specific change addresses an issue where holding the arrow keys during video seeking caused repeated seek operations to the same position—up to 27 times in one case. This behavior resulted in the video player being stuck in a loading state, as each completed seek triggered another to the same position. This refactor aims to optimize the seek functionality and prevent redundant operations to enhance the viewing experience.