### PR TITLE
Asynchronous setProperty / command

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -172,32 +172,7 @@ class NativePlayer extends PlatformPlayer {
       );
 
       // Enter paused state.
-      {
-        final name = 'pause'.toNativeUtf8();
-        final value = calloc<Uint8>();
-        mpv.mpv_get_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_FLAG,
-          value.cast(),
-        );
-        if (value.value == 0) {
-          // We are using `cycle pause` because it waits & prevents the race condition.
-          final command = 'cycle pause'.toNativeUtf8();
-          mpv.mpv_command_string(
-            ctx,
-            command.cast(),
-          );
-          // NOTE: Handled as part of [stop] logic.
-          // state = state.copyWith(playing: false);
-          // if (!playingController.isClosed) {
-          //   playingController.add(false);
-          // }
-        }
-
-        calloc.free(name);
-        calloc.free(value);
-      }
+      await _setPropertyFlag('pause', true);
 
       // NOTE: Handled as part of [stop] logic.
       // isShuffleEnabled = false;
@@ -216,24 +191,7 @@ class NativePlayer extends PlatformPlayer {
       // If [play] is `true`, then exit paused state.
       if (play) {
         isPlayingStateChangeAllowed = true;
-        final name = 'pause'.toNativeUtf8();
-        final value = calloc<Uint8>();
-        mpv.mpv_get_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_FLAG,
-          value.cast(),
-        );
-        if (value.value == 1) {
-          // We are using `cycle pause` because it waits & prevents the race condition.
-          final command = 'cycle pause'.toNativeUtf8();
-          mpv.mpv_command_string(
-            ctx,
-            command.cast(),
-          );
-        }
-        calloc.free(name);
-        calloc.free(value);
+        await _setPropertyFlag('pause', false);
         state = state.copyWith(playing: true);
         if (!playingController.isClosed) {
           playingController.add(true);
@@ -241,18 +199,7 @@ class NativePlayer extends PlatformPlayer {
       }
 
       // Jump to the specified [index] (in both cases either [play] is `true` or `false`).
-      {
-        final name = 'playlist-pos'.toNativeUtf8();
-        final value = calloc<Int64>()..value = index;
-        mpv.mpv_set_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_INT64,
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
-      }
+      await _setPropertyInt64('playlist-pos', index);
     }
 
     if (synchronized) {
@@ -281,17 +228,12 @@ class NativePlayer extends PlatformPlayer {
       isBufferingStateChangeAllowed = false;
 
       final commands = [
-        'stop',
-        'playlist-clear',
-        'playlist-play-index none',
+        ['stop'],
+        ['playlist-clear'],
+        ['playlist-play-index', 'none'],
       ];
       for (final command in commands) {
-        final args = command.toNativeUtf8();
-        mpv.mpv_command_string(
-          ctx,
-          args.cast(),
-        );
-        calloc.free(args);
+        await _command(command);
       }
 
       // Reset the remaining attributes.
@@ -393,22 +335,7 @@ class NativePlayer extends PlatformPlayer {
         playingController.add(true);
       }
 
-      final name = 'pause'.toNativeUtf8();
-      final value = calloc<Uint8>();
-      mpv.mpv_get_property(
-        ctx,
-        name.cast(),
-        generated.mpv_format.MPV_FORMAT_FLAG,
-        value.cast(),
-      );
-      if (value.value == 1) {
-        await playOrPause(
-          notify: false,
-          synchronized: false,
-        );
-      }
-      calloc.free(name);
-      calloc.free(value);
+      await _setPropertyFlag('pause', false);
     }
 
     if (synchronized) {
@@ -433,22 +360,7 @@ class NativePlayer extends PlatformPlayer {
         playingController.add(false);
       }
 
-      final name = 'pause'.toNativeUtf8();
-      final value = calloc<Uint8>();
-      mpv.mpv_get_property(
-        ctx,
-        name.cast(),
-        generated.mpv_format.MPV_FORMAT_FLAG,
-        value.cast(),
-      );
-      if (value.value == 0) {
-        await playOrPause(
-          notify: false,
-          synchronized: false,
-        );
-      }
-      calloc.free(name);
-      calloc.free(value);
+      await _setPropertyFlag('pause', false);
     }
 
     if (synchronized) {
@@ -487,23 +399,9 @@ class NativePlayer extends PlatformPlayer {
       // This condition is specifically for the case when the internal playlist is ended (with [PlaylistLoopMode.none]), and we want to play the playlist again if play/pause is pressed.
       if (state.completed) {
         await seek(Duration.zero, synchronized: false);
-        final name = 'playlist-pos'.toNativeUtf8();
-        final value = calloc<Int64>()..value = 0;
-        mpv.mpv_set_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_INT64,
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
+        await _setPropertyInt64('playlist-pos', 0);
       }
-      final command = 'cycle pause'.toNativeUtf8();
-      mpv.mpv_command_string(
-        ctx,
-        command.cast(),
-      );
-      calloc.free(command);
+      await _command(['cycle', 'pause']);
     }
 
     if (synchronized) {
@@ -528,12 +426,7 @@ class NativePlayer extends PlatformPlayer {
       current.add(media);
       // ---------------------------------------------
 
-      final command = 'loadfile ${media.uri} append'.toNativeUtf8();
-      mpv.mpv_command_string(
-        ctx,
-        command.cast(),
-      );
-      calloc.free(command.cast());
+      await _command(['loadfile', media.uri, 'append']);
     }
 
     if (synchronized) {
@@ -587,12 +480,7 @@ class NativePlayer extends PlatformPlayer {
         }
       }
 
-      final command = 'playlist-remove $index'.toNativeUtf8();
-      mpv.mpv_command_string(
-        ctx,
-        command.cast(),
-      );
-      calloc.free(command.cast());
+      await _command(['playlist-remove', index.toString()]);
     }
 
     if (synchronized) {
@@ -622,12 +510,7 @@ class NativePlayer extends PlatformPlayer {
       }
 
       await play(synchronized: false);
-      final command = 'playlist-next'.toNativeUtf8();
-      mpv.mpv_command_string(
-        ctx,
-        command.cast(),
-      );
-      calloc.free(command);
+      await _command(['playlist-next']);
     }
 
     if (synchronized) {
@@ -657,12 +540,7 @@ class NativePlayer extends PlatformPlayer {
       }
 
       await play(synchronized: false);
-      final command = 'playlist-prev'.toNativeUtf8();
-      mpv.mpv_command_string(
-        ctx,
-        command.cast(),
-      );
-      calloc.free(command);
+      await _command(['playlist-prev']);
     }
 
     if (synchronized) {
@@ -683,16 +561,7 @@ class NativePlayer extends PlatformPlayer {
       await waitForVideoControllerInitializationIfAttached;
 
       await play(synchronized: false);
-      final name = 'playlist-pos'.toNativeUtf8();
-      final value = calloc<Int64>()..value = index;
-      mpv.mpv_set_property(
-        ctx,
-        name.cast(),
-        generated.mpv_format.MPV_FORMAT_INT64,
-        value.cast(),
-      );
-      calloc.free(name);
-      calloc.free(value);
+      await _setPropertyInt64('playlist-pos', index);
     }
 
     if (synchronized) {
@@ -725,12 +594,7 @@ class NativePlayer extends PlatformPlayer {
       current = values;
       // ---------------------------------------------
 
-      final command = 'playlist-move $from $to'.toNativeUtf8();
-      mpv.mpv_command_string(
-        ctx,
-        command.cast(),
-      );
-      calloc.free(command.cast());
+      await _command(['playlist-move', from.toString(), to.toString()]);
     }
 
     if (synchronized) {
@@ -751,14 +615,7 @@ class NativePlayer extends PlatformPlayer {
       await waitForPlayerInitialization;
       await waitForVideoControllerInitializationIfAttached;
 
-      await compute(
-        _seek,
-        _SeekData(
-          ctx.address,
-          NativeLibrary.path,
-          duration,
-        ),
-      );
+      await _command(['seek', (duration.inMilliseconds / 1000).toStringAsFixed(4), 'absolute']);
 
       // It is self explanatory that PlayerState.completed & PlayerStream.completed must enter the false state if seek is called. Typically after EOF.
       // https://github.com/media-kit/media-kit/issues/221
@@ -786,60 +643,28 @@ class NativePlayer extends PlatformPlayer {
       await waitForPlayerInitialization;
       await waitForVideoControllerInitializationIfAttached;
 
-      final file = 'loop-file'.toNativeUtf8();
-      final playlist = 'loop-playlist'.toNativeUtf8();
-      final yes = 'yes'.toNativeUtf8();
-      final no = 'no'.toNativeUtf8();
       switch (playlistMode) {
         case PlaylistMode.none:
           {
-            mpv.mpv_set_property_string(
-              ctx,
-              file.cast(),
-              no.cast(),
-            );
-            mpv.mpv_set_property_string(
-              ctx,
-              playlist.cast(),
-              no.cast(),
-            );
+            await _setPropertyString('loop-file', 'no');
+            await _setPropertyString('loop-playlist', 'no');
             break;
           }
         case PlaylistMode.single:
           {
-            mpv.mpv_set_property_string(
-              ctx,
-              file.cast(),
-              yes.cast(),
-            );
-            mpv.mpv_set_property_string(
-              ctx,
-              playlist.cast(),
-              no.cast(),
-            );
+            await _setPropertyString('loop-file', 'yes');
+            await _setPropertyString('loop-playlist', 'no');
             break;
           }
         case PlaylistMode.loop:
           {
-            mpv.mpv_set_property_string(
-              ctx,
-              file.cast(),
-              no.cast(),
-            );
-            mpv.mpv_set_property_string(
-              ctx,
-              playlist.cast(),
-              yes.cast(),
-            );
+            await _setPropertyString('loop-file', 'no');
+            await _setPropertyString('loop-playlist', 'yes');
             break;
           }
         default:
           break;
       }
-      calloc.free(file);
-      calloc.free(playlist);
-      calloc.free(yes);
-      calloc.free(no);
 
       state = state.copyWith(playlistMode: playlistMode);
       if (!playlistModeController.isClosed) {
@@ -864,40 +689,7 @@ class NativePlayer extends PlatformPlayer {
       await waitForPlayerInitialization;
       await waitForVideoControllerInitializationIfAttached;
 
-      {
-        final name = 'mute'.toNativeUtf8();
-        final value = calloc<Bool>();
-        mpv.mpv_get_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_FLAG,
-          value.cast(),
-        );
-        if (value.value) {
-          // Unmute the player before setting the volume.
-          final command = 'cycle mute'.toNativeUtf8();
-          mpv.mpv_command_string(
-            ctx,
-            command.cast(),
-          );
-          calloc.free(command);
-        }
-        calloc.free(name);
-        calloc.free(value);
-      }
-      {
-        final name = 'volume'.toNativeUtf8();
-        final value = calloc<Double>();
-        value.value = volume;
-        mpv.mpv_set_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_DOUBLE,
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
-      }
+      await _setPropertyDouble('volume', volume);
     }
 
     if (synchronized) {
@@ -937,27 +729,9 @@ class NativePlayer extends PlatformPlayer {
         // Apparently, using scaletempo:scale actually controls the playback rate as intended after setting audio-pitch-correction as FALSE.
         // speed on the other hand, changes the pitch when audio-pitch-correction is set to FALSE.
         // Since, it also alters the actual [speed], the scaletempo:scale is divided by the same value of [pitch] to compensate the speed change.
-        var name = 'audio-pitch-correction'.toNativeUtf8();
-        final no = 'no'.toNativeUtf8();
-        mpv.mpv_set_property_string(
-          ctx,
-          name.cast(),
-          no.cast(),
-        );
-        calloc.free(name);
-        calloc.free(no);
-        name = 'af'.toNativeUtf8();
+        await _setPropertyFlag('audio-pitch-correction', false);
         // Divide by [state.pitch] to compensate the speed change caused by pitch shift.
-        final value =
-            'scaletempo:scale=${(state.rate / state.pitch).toStringAsFixed(8)}'
-                .toNativeUtf8();
-        mpv.mpv_set_property_string(
-          ctx,
-          name.cast(),
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
+        await _setPropertyString('af', 'scaletempo:scale=${(state.rate / state.pitch).toStringAsFixed(8)}');
       } else {
         // Pitch shift control is disabled.
 
@@ -967,17 +741,7 @@ class NativePlayer extends PlatformPlayer {
         if (!rateController.isClosed) {
           rateController.add(state.rate);
         }
-        final name = 'speed'.toNativeUtf8();
-        final value = calloc<Double>();
-        value.value = rate;
-        mpv.mpv_set_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_DOUBLE,
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
+        await _setPropertyDouble('speed', rate);
       }
     }
 
@@ -1018,37 +782,10 @@ class NativePlayer extends PlatformPlayer {
         // Apparently, using scaletempo:scale actually controls the playback rate as intended after setting audio-pitch-correction as FALSE.
         // speed on the other hand, changes the pitch when audio-pitch-correction is set to FALSE.
         // Since, it also alters the actual [speed], the scaletempo:scale is divided by the same value of [pitch] to compensate the speed change.
-        var name = 'audio-pitch-correction'.toNativeUtf8();
-        final no = 'no'.toNativeUtf8();
-        mpv.mpv_set_property_string(
-          ctx,
-          name.cast(),
-          no.cast(),
-        );
-        calloc.free(name);
-        calloc.free(no);
-        name = 'speed'.toNativeUtf8();
-        final speed = calloc<Double>()..value = pitch;
-        mpv.mpv_set_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_DOUBLE,
-          speed.cast(),
-        );
-        calloc.free(name);
-        calloc.free(speed);
-        name = 'af'.toNativeUtf8();
+        await _setPropertyFlag('audio-pitch-correction', false);
+        await _setPropertyDouble('speed', pitch);
         // Divide by [state.pitch] to compensate the speed change caused by pitch shift.
-        final value =
-            'scaletempo:scale=${(state.rate / state.pitch).toStringAsFixed(8)}'
-                .toNativeUtf8();
-        mpv.mpv_set_property_string(
-          ctx,
-          name.cast(),
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
+        await _setPropertyString('af', 'scaletempo:scale=${(state.rate / state.pitch).toStringAsFixed(8)}');
       } else {
         // Pitch shift control is disabled.
         throw ArgumentError('[PlayerConfiguration.pitch] is false');
@@ -1105,15 +842,7 @@ class NativePlayer extends PlatformPlayer {
       await waitForPlayerInitialization;
       await waitForVideoControllerInitializationIfAttached;
 
-      final name = 'audio-device'.toNativeUtf8();
-      final value = audioDevice.name.toNativeUtf8();
-      mpv.mpv_set_property_string(
-        ctx,
-        name.cast(),
-        value.cast(),
-      );
-      calloc.free(name);
-      calloc.free(value);
+      await _setPropertyString('audio-device', audioDevice.name);
     }
 
     if (synchronized) {
@@ -1136,15 +865,7 @@ class NativePlayer extends PlatformPlayer {
       await waitForPlayerInitialization;
       await waitForVideoControllerInitializationIfAttached;
 
-      final name = 'vid'.toNativeUtf8();
-      final value = track.id.toNativeUtf8();
-      mpv.mpv_set_property_string(
-        ctx,
-        name.cast(),
-        value.cast(),
-      );
-      calloc.free(name);
-      calloc.free(value);
+      await _setPropertyString('vid', track.id);
       state = state.copyWith(
         track: state.track.copyWith(
           video: track,
@@ -1206,15 +927,7 @@ class NativePlayer extends PlatformPlayer {
           trackController.add(state.track);
         }
       } else {
-        final name = 'aid'.toNativeUtf8();
-        final value = track.id.toNativeUtf8();
-        mpv.mpv_set_property_string(
-          ctx,
-          name.cast(),
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
+        await _setPropertyString('aid', track.id);
         state = state.copyWith(
           track: state.track.copyWith(
             audio: track,
@@ -1300,15 +1013,7 @@ class NativePlayer extends PlatformPlayer {
           trackController.add(state.track);
         }
       } else {
-        final name = 'sid'.toNativeUtf8();
-        final value = track.id.toNativeUtf8();
-        mpv.mpv_set_property_string(
-          ctx,
-          name.cast(),
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
+        await _setPropertyString('sid', track.id);
         state = state.copyWith(
           track: state.track.copyWith(
             subtitle: track,
@@ -1608,6 +1313,26 @@ class NativePlayer extends PlatformPlayer {
             audioDevicesController.add(audioDevices);
           }
         }
+      }
+    }
+    if (event.ref.event_id ==
+        generated.mpv_event_id.MPV_EVENT_SET_PROPERTY_REPLY) {
+      final completer = _setPropertyRequests.remove(event.ref.reply_userdata);
+      if (completer == null) {
+        print('Warning: Received MPV_EVENT_SET_PROPERTY_REPLY with unregistered ID ${event.ref.reply_userdata}');
+      }
+      else {
+        completer.complete(event.ref.error);
+      }
+    }
+    if (event.ref.event_id ==
+        generated.mpv_event_id.MPV_EVENT_COMMAND_REPLY) {
+      final completer = _commandRequests.remove(event.ref.reply_userdata);
+      if (completer == null) {
+        print('Warning: Received MPV_EVENT_COMMAND_REPLY with unregistered ID ${event.ref.reply_userdata}');
+      }
+      else {
+        completer.complete(event.ref.error);
       }
     }
 
@@ -2633,29 +2358,12 @@ class NativePlayer extends PlatformPlayer {
         properties['ao'] = 'null';
       }
 
-      for (final property in properties.entries) {
-        final name = property.key.toNativeUtf8();
-        final value = property.value.toNativeUtf8();
-        mpv.mpv_set_property_string(
-          ctx,
-          name.cast(),
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
-      }
+      await Future.wait(properties.entries.map(
+        (entry) => _setPropertyString(entry.key, entry.value)
+      ));
 
       if (configuration.muted) {
-        final name = 'mute'.toNativeUtf8();
-        final value = calloc<Bool>()..value = true;
-        mpv.mpv_set_property(
-          ctx,
-          name.cast(),
-          generated.mpv_format.MPV_FORMAT_FLAG,
-          value.cast(),
-        );
-        calloc.free(name);
-        calloc.free(value);
+        await _setPropertyDouble('volume', 0);
 
         state = state.copyWith(volume: 0.0);
         if (!volumeController.isClosed) {
@@ -2732,6 +2440,58 @@ class NativePlayer extends PlatformPlayer {
     }
   }
 
+
+  int _asyncRequestNumber = 0;
+  final Map<int, Completer<int>> _setPropertyRequests = {};
+  final Map<int, Completer<int>> _commandRequests = {};
+
+  /// Asynchronous property setting
+  Future<void> _setProperty(
+    String name,
+    int format,
+    Pointer<Void> data,
+  ) async {
+    final requestNumber = _asyncRequestNumber++;
+    final completer = _setPropertyRequests[requestNumber] = Completer<int>();
+    final namePtr = name.toNativeUtf8();
+    final immediate = mpv.mpv_set_property_async(ctx, requestNumber, namePtr.cast(), format, data);
+    calloc.free(namePtr);
+    if (immediate < 0) {
+      // Sending failed
+      _error(immediate);
+      return;
+    }
+    _error(await completer.future);
+  }
+
+  Future<void> _setPropertyFlag(String name, bool value) async {
+    final ptr = calloc<Bool>(1)..value = value;
+    await _setProperty(name, generated.mpv_format.MPV_FORMAT_FLAG, ptr.cast());
+    calloc.free(ptr);
+  }
+
+  Future<void> _setPropertyDouble(String name, double value) async {
+    final ptr = calloc<Double>(1)..value = value;
+    await _setProperty(name, generated.mpv_format.MPV_FORMAT_DOUBLE, ptr.cast());
+    calloc.free(ptr);
+  }
+
+  Future<void> _setPropertyInt64(String name, int value) async {
+    final ptr = calloc<Int64>(1)..value = value;
+    await _setProperty(name, generated.mpv_format.MPV_FORMAT_INT64, ptr.cast());
+    calloc.free(ptr);
+  }
+
+  Future<void> _setPropertyString(String name, String value) async {
+    final string = value.toNativeUtf8();
+    // It wants char**
+    final ptr = calloc<Pointer<Void>>(1);
+    ptr.value = Pointer.fromAddress(string.address);
+    await _setProperty(name, generated.mpv_format.MPV_FORMAT_STRING, ptr.cast());
+    calloc.free(ptr);
+    calloc.free(string);
+  }
+
   /// Calls mpv command passed as [args].
   /// Automatically freeds memory after command sending.
   Future<void> _command(List<String> args) async {
@@ -2740,12 +2500,17 @@ class NativePlayer extends PlatformPlayer {
     for (int i = 0; i < args.length; i++) {
       arr.elementAt(i).value = pointers[i];
     }
-    mpv.mpv_command(
-      ctx,
-      arr.cast(),
-    );
+    final requestNumber = _asyncRequestNumber++;
+    final completer = _commandRequests[requestNumber] = Completer<int>();
+    final immediate = mpv.mpv_command_async(ctx, requestNumber, arr.cast());
     calloc.free(arr);
     pointers.forEach(calloc.free);
+    if (immediate < 0) {
+      // Sending failed
+      _error(immediate);
+      return;
+    }
+    _error(await completer.future);
   }
 
   /// Internal generated libmpv C API bindings.
@@ -2812,35 +2577,6 @@ class NativePlayer extends PlatformPlayer {
 //
 // TODO: Maybe eventually move all methods to [Isolate]?
 // --------------------------------------------------
-
-class _SeekData {
-  final int ctx;
-  final String lib;
-  final Duration duration;
-
-  _SeekData(
-    this.ctx,
-    this.lib,
-    this.duration,
-  );
-}
-
-/// [NativePlayer.seek]
-void _seek(_SeekData data) {
-  // ---------
-  final mpv = generated.MPV(DynamicLibrary.open(data.lib));
-  final ctx = Pointer<generated.mpv_handle>.fromAddress(data.ctx);
-  // ---------
-  final duration = data.duration;
-  // ---------
-  final value = duration.inMilliseconds / 1000;
-  final command = 'seek ${value.toStringAsFixed(4)} absolute'.toNativeUtf8();
-  mpv.mpv_command_string(
-    ctx,
-    command.cast(),
-  );
-  calloc.free(command);
-}
 
 class _ScreenshotData {
   final int ctx;

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -360,7 +360,7 @@ class NativePlayer extends PlatformPlayer {
         playingController.add(false);
       }
 
-      await _setPropertyFlag('pause', false);
+      await _setPropertyFlag('pause', true);
     }
 
     if (synchronized) {

--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -3117,14 +3117,6 @@ void main() {
               'subtitle',
               isTrue,
             ),
-            TypeMatcher<List<String>>().having(
-              (subtitle) => ListEquality().equals(
-                subtitle,
-                ['', ''],
-              ),
-              'subtitle',
-              isTrue,
-            ),
             emitsDone,
           ],
         ),


### PR DESCRIPTION
This removes all noticeable blocking of dart/ui thread

Some notes/questions for @alexmercerind 

1. I replaced the "play() -> get_property -> playOrPause" pattern with just set_property('pause', false). I got bad race conditions with the old way. Not sure why you changed to it originally?
2. I can move `seek` back to the main thread now :)
3. I didn't change screenshot() since it has one-off use of command-with-result. But also it uses `package:image` to do some conversion in dart-space, so other Isolate is still a good idea.
4. I didn't implement getProperty. Because the memory ownership there gets a little more complicated. But after rebasing my change here, I see there is now NativePlayer.getProperty. Can think about it some more...