### PR TITLE
Fix swapped iOS texture dimensions

### DIFF
--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -189,11 +189,11 @@ public class VideoOutput: NSObject {
         let params = MPVHelpers.getVideoOutParams(handle)
         return CGSize(
             width: Double(width ?? (params.rotate == 0 || params.rotate == 180
-                                    ? params.dh
-                                    : params.dw)),
+                                    ? params.dw
+                                    : params.dh)),
             height: Double(height ?? (params.rotate == 0 || params.rotate == 180
-                                      ? params.dw
-                                      : params.dh))
+                                      ? params.dh
+                                      : params.dw))
         )
   }
 }


### PR DESCRIPTION
I swapped the dimensions by mistake in https://github.com/media-kit/media-kit/pull/814