### PR TITLE
do not log plugin registration in stdout

### DIFF
--- a/libs/linux/media_kit_libs_linux/linux/media_kit_libs_linux_plugin.cc
+++ b/libs/linux/media_kit_libs_linux/linux/media_kit_libs_linux_plugin.cc
@@ -7,11 +7,8 @@
 
 #include "include/media_kit_libs_linux/media_kit_libs_linux_plugin.h"
 
-#include <stdio.h>
 #include <locale.h>
 
 void media_kit_libs_linux_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
-  printf("package:media_kit_libs_linux registered.\n");
-  fflush(stdout);
   setlocale(LC_NUMERIC, "C");
 }

--- a/libs/windows/media_kit_libs_windows_audio/windows/media_kit_libs_windows_audio_plugin_c_api.cpp
+++ b/libs/windows/media_kit_libs_windows_audio/windows/media_kit_libs_windows_audio_plugin_c_api.cpp
@@ -1,9 +1,6 @@
 #include "include/media_kit_libs_windows_audio/media_kit_libs_windows_audio_plugin_c_api.h"
 
-#include <iostream>
-
 #include <flutter/plugin_registrar_windows.h>
 
 void MediaKitLibsWindowsAudioPluginCApiRegisterWithRegistrar(FlutterDesktopPluginRegistrarRef registrar) {
-  std::cout << "package:media_kit_libs_windows_audio registered." << std::endl;
 }

--- a/libs/windows/media_kit_libs_windows_video/windows/media_kit_libs_windows_video_plugin_c_api.cpp
+++ b/libs/windows/media_kit_libs_windows_video/windows/media_kit_libs_windows_video_plugin_c_api.cpp
@@ -1,9 +1,6 @@
 #include "include/media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h"
 
-#include <iostream>
-
 #include <flutter/plugin_registrar_windows.h>
 
 void MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(FlutterDesktopPluginRegistrarRef registrar) {
-  std::cout << "package:media_kit_libs_windows_video registered." << std::endl;
 }


### PR DESCRIPTION
For a flutter desktop application, I need to be able to just return some information on the standard output when some flags are passed from the CLI and exit the application.

All works fine except that media_kit plugin prints a string to the stdout when it is registered.

This PR just removes these prints.