### PR TITLE
removed libmpv.so.1 dependency as libmpv.so.2 is the new thing.

### DIFF
--- a/media_kit/lib/src/player/native/core/native_library.dart
+++ b/media_kit/lib/src/player/native/core/native_library.dart
@@ -53,7 +53,6 @@ abstract class NativeLibrary {
       'linux': [
         'libmpv.so',
         'libmpv.so.2',
-        'libmpv.so.1',
       ],
       'macos': [
         'Mpv.framework/Mpv',


### PR DESCRIPTION
libmpv.so.1 is not present on most Linux systems with mpv installed. that issue was remedied by symlinking libmpv.so.2 to libmpv.so.1. this commit only removes that dependency. 