### PR TITLE
Fixes volume slider affected by click-and-drag

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -630,7 +630,7 @@ class _MaterialDesktopVideoControlsState
                         }
                       },
 
-                onPanUpdate: _theme(context).modifyVolumeOnScroll
+                /* onPanUpdate: _theme(context).modifyVolumeOnScroll
                     ? (e) {
                         if (e.delta.dy > 0) {
                           final volume =
@@ -647,7 +647,7 @@ class _MaterialDesktopVideoControlsState
                               .setVolume(volume.clamp(0.0, 100.0));
                         }
                       }
-                    : null,
+                    : null, */
                 child: MouseRegion(
                   cursor: (_theme(context).hideMouseOnControlsRemoval && !mount)
                       ? SystemMouseCursors.none


### PR DESCRIPTION
When performing click-and-drag on the seek bar or on the video surface, the code that's commented out affects the volume slider.