### PR TITLE
Fix application/vnd.apple.mpegurl type HLS check for Chrome on Android

### DIFF
--- a/media_kit/lib/src/player/web/player/real.dart
+++ b/media_kit/lib/src/player/web/player/real.dart
@@ -1438,9 +1438,6 @@ class WebPlayer extends PlatformPlayer {
   }
 
   bool _isHLS(String src) {
-    if (element.canPlayType('application/vnd.apple.mpegurl') != '') {
-      return false;
-    }
     if (isHLSSupported() && src.toLowerCase().contains('m3u8')) {
       return true;
     }

--- a/media_kit/lib/src/player/web/player/real.dart
+++ b/media_kit/lib/src/player/web/player/real.dart
@@ -1438,6 +1438,14 @@ class WebPlayer extends PlatformPlayer {
   }
 
   bool _isHLS(String src) {
+    final userAgent = html.window.navigator.userAgent;
+    final isAndroidChrome =
+        userAgent.contains("Android") && userAgent.contains("Chrome");
+
+    if (!isAndroidChrome &&
+        element.canPlayType('application/vnd.apple.mpegurl') != '') {
+      return false;
+    }
     if (isHLSSupported() && src.toLowerCase().contains('m3u8')) {
       return true;
     }


### PR DESCRIPTION
Use hls.js isHLSSupported check only.
In relation to issue https://github.com/media-kit/media-kit/issues/880.

This fixes playing HLS m3u8 stream on Chrome on Android using Flutter Web.