### PR TITLE
fix: adjust stub templates to comply with real types

### DIFF
--- a/media_kit/lib/src/player/native/player/stub.dart
+++ b/media_kit/lib/src/player/native/player/stub.dart
@@ -3,9 +3,12 @@
 /// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
 /// All rights reserved.
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
-import 'package:meta/meta.dart';
+import 'dart:collection';
 
 import 'package:media_kit/src/player/platform_player.dart';
+import 'package:meta/meta.dart';
+
+import '../../../models/media/media.dart';
 
 void nativeEnsureInitialized({String? libmpv}) {}
 
@@ -15,4 +18,38 @@ class NativePlayer extends PlatformPlayer {
   /// Whether the [NativePlayer] is initialized for unit-testing.
   @visibleForTesting
   static bool test = false;
+
+  Object? get ctx => throw UnimplementedError();
+
+  List<Media> current = [];
+
+  bool disposed = false;
+
+  Future<void>? future;
+
+  bool isBufferingStateChangeAllowed = true;
+
+  bool isPlayingStateChangeAllowed = true;
+
+  bool isShuffleEnabled = true;
+
+  Future<void> command(List<String> command) async {}
+
+  Future<String> getProperty(String property) => throw UnimplementedError();
+
+  get mpv => throw UnimplementedError();
+
+  Future<void> observeProperty(
+      String property, Future<void> Function(String p1) listener) async {}
+
+  HashMap<String, Future<void> Function(String p1)> get observed =>
+      throw UnimplementedError();
+
+  List<Future<void> Function()> get onLoadHooks => [];
+
+  List<Future<void> Function()> get onUnloadHooks => [];
+
+  Future<void> setProperty(String property, String value) async {}
+
+  Future<void> unobserveProperty(String property) async {}
 }

--- a/media_kit/lib/src/player/web/player/stub.dart
+++ b/media_kit/lib/src/player/web/player/stub.dart
@@ -3,9 +3,9 @@
 /// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
 /// All rights reserved.
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
-import 'package:meta/meta.dart';
-
 import 'package:media_kit/src/player/platform_player.dart';
+import 'package:meta/meta.dart';
+import 'package:synchronized/synchronized.dart';
 
 void webEnsureInitialized({String? libmpv}) {}
 
@@ -15,4 +15,12 @@ class WebPlayer extends PlatformPlayer {
   /// Whether the [WebPlayer] is initialized for unit-testing.
   @visibleForTesting
   static bool test = false;
+
+  bool disposed = false;
+
+  get element => throw UnimplementedError();
+
+  int get id => 0;
+
+  Lock get lock => Lock();
 }


### PR DESCRIPTION
This harmonizes the signature of the `stub.dart` and `real.dart` of both `NativePlayer` and `WebPlayer` as best practice for all its public members potentially used by third party packages (in my case [`just_audio_media_kit` bindings](https://pub.dev/packages/just_audio_media_kit)) or directly by application developers.

I see no potential regressions in it.

Fixes: #886