### PR TITLE
fix: set width/height from `VideoParams` in `NativeVideoController`

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -43,6 +43,10 @@ void nativeEnsureInitialized({String? libmpv}) {
   AndroidHelper.ensureInitialized();
   NativeLibrary.ensureInitialized(libmpv: libmpv);
   NativeReferenceHolder.ensureInitialized((references) async {
+    if (references.isEmpty) {
+      return;
+    }
+    print('media_kit: Found ${references.length} reference(s). Disposing...');
     // I can only get quit to work; [mpv_terminate_destroy] causes direct crash.
     final mpv = generated.MPV(DynamicLibrary.open(NativeLibrary.path));
     final cmd = 'quit'.toNativeUtf8();
@@ -2337,6 +2341,9 @@ class NativePlayer extends PlatformPlayer {
         'dscale': 'bilinear',
         'dither': 'no',
         'cache': 'yes',
+        'cache-on-disk': 'yes',
+        'hr-seek': 'yes',
+        'hr-seek-framedrop': 'no',
         'correct-downscaling': 'no',
         'linear-downscaling': 'no',
         'sigmoid-upscaling': 'no',

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -1416,10 +1416,10 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                         if (_theme(context)
                                 .seekOnDoubleTapLayoutWidgetRatios[1] >
                             0)
-                          Expanded(
-                              flex: _theme(context)
-                                  .seekOnDoubleTapLayoutWidgetRatios[1],
-                              child: SizedBox()),
+                          Spacer(
+                            flex: _theme(context)
+                                .seekOnDoubleTapLayoutWidgetRatios[1],
+                          ),
                         Expanded(
                           flex: _theme(context)
                               .seekOnDoubleTapLayoutWidgetRatios[2],
@@ -1582,6 +1582,7 @@ class MaterialSeekBarState extends State<MaterialSeekBar> {
       tapped = true;
       slider = percent.clamp(0.0, 1.0);
     });
+    controller(context).player.seek(duration * slider);
   }
 
   void onPointerDown() {
@@ -1594,13 +1595,11 @@ class MaterialSeekBarState extends State<MaterialSeekBar> {
   void onPointerUp() {
     widget.onSeekEnd?.call();
     setState(() {
-      tapped = false;
-    });
-    controller(context).player.seek(duration * slider);
-    setState(() {
       // Explicitly set the position to prevent the slider from jumping.
+      tapped = false;
       position = duration * slider;
     });
+    controller(context).player.seek(duration * slider);
   }
 
   void onPanStart(DragStartDetails e, BoxConstraints constraints) {

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -185,7 +185,7 @@ class MaterialDesktopVideoControlsThemeData {
     this.automaticallyImplySkipNextButton = true,
     this.automaticallyImplySkipPreviousButton = true,
     this.toggleFullscreenOnDoublePress = true,
-    this.playAndPauseOnTap = true,
+    this.playAndPauseOnTap = false,
     this.modifyVolumeOnScroll = true,
     this.keyboardShortcuts,
     this.visibleOnMount = false,
@@ -629,7 +629,6 @@ class _MaterialDesktopVideoControlsState
                           toggleFullscreen(context);
                         }
                       },
-
                 onPanUpdate: _theme(context).modifyVolumeOnScroll
                     ? (e) {
                         if (e.delta.dy > 0) {
@@ -956,6 +955,7 @@ class MaterialDesktopSeekBarState extends State<MaterialDesktopSeekBar> {
       hover = true;
       slider = percent.clamp(0.0, 1.0);
     });
+    controller(context).player.seek(duration * slider);
   }
 
   void onPointerDown() {
@@ -968,13 +968,11 @@ class MaterialDesktopSeekBarState extends State<MaterialDesktopSeekBar> {
   void onPointerUp() {
     widget.onSeekEnd?.call();
     setState(() {
-      click = false;
-    });
-    controller(context).player.seek(duration * slider);
-    setState(() {
       // Explicitly set the position to prevent the slider from jumping.
+      click = false;
       position = duration * slider;
     });
+    controller(context).player.seek(duration * slider);
   }
 
   void onHover(PointerHoverEvent e, BoxConstraints constraints) {

--- a/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
@@ -27,12 +27,6 @@ class AndroidVideoController extends PlatformVideoController {
   /// Whether [AndroidVideoController] is supported on the current platform or not.
   static bool get supported => Platform.isAndroid;
 
-  /// Fixed width of the video output.
-  int? width;
-
-  /// Fixed height of the video output.
-  int? height;
-
   /// Pointer address to the global object reference of `android.view.Surface` i.e. `(intptr_t)(*android.view.Surface)`.
   final ValueNotifier<int?> wid = ValueNotifier<int?>(null);
 
@@ -110,11 +104,6 @@ class AndroidVideoController extends PlatformVideoController {
     wid.addListener(widListener);
     platform.onLoadHooks.add(onLoadHook);
     platform.onUnloadHooks.add(onUnloadHook);
-
-    // This setup is here within Dart (unlike [NativeVideoController]) primarily for two reasons:
-    // * We use --wid & do not run own render loop.
-    // * Native listener/callback within JNI would be redundantly complex.
-
     videoParamsSubscription = player.stream.videoParams.listen(
       (event) => lock.synchronized(() async {
         if ([0, null].contains(event.dw) || [0, null].contains(event.dh)) {


### PR DESCRIPTION
- Prevent querying `mpv_get_property` on each render.
- Not changing native code to prevent any potential issues (happens to be very stable).