### PR TITLE
fix: `NativeReferenceHolder` on 32-bit systems

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -46,7 +46,10 @@ void nativeEnsureInitialized({String? libmpv}) {
     if (references.isEmpty) {
       return;
     }
-    print('media_kit: Found ${references.length} reference(s). Disposing...');
+    const tag = NativeReferenceHolder.kTag;
+    print('$tag Found ${references.length} reference(s).');
+    print('$tag Disposing:\n${references.map((e) => e.address).join('\n')}');
+
     // I can only get quit to work; [mpv_terminate_destroy] causes direct crash.
     final mpv = generated.MPV(DynamicLibrary.open(NativeLibrary.path));
     final cmd = 'quit'.toNativeUtf8();


### PR DESCRIPTION
The [`.value` getter](https://api.flutter.dev/flutter/dart-ffi/AbiSpecificIntegerPointer/value.html) can return integer value not equal to the actual address (especially on 32-bit systems). The [`.address` getter](https://api.flutter.dev/flutter/dart-ffi/Pointer/address.html) is now being used for accessing the raw integer address.

Primarily an issue with signed/unsigned nature of things.