### PR TITLE
fix: video_player black screen

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2460,7 +2460,7 @@ class NativePlayer extends PlatformPlayer {
     if (code < 0 && !logController.isClosed) {
       final message = mpv.mpv_error_string(code).cast<Utf8>().toDartString();
       logController.add(PlayerLog(
-          prefix: "", level: 'error', text: 'error:$message $extraContext'));
+          prefix: "media_kit", level: 'error', text: 'error:$message $extraContext'));
     }
   }
 

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2456,11 +2456,14 @@ class NativePlayer extends PlatformPlayer {
   }
 
   /// Adds an error to the [Player.stream.error].
-  void _logError(int code, String? extraContext) {
+  void _logError(int code, String? text) {
     if (code < 0 && !logController.isClosed) {
       final message = mpv.mpv_error_string(code).cast<Utf8>().toDartString();
       logController.add(PlayerLog(
-          prefix: "media_kit", level: 'error', text: 'error:$message $extraContext'));
+        prefix: 'media_kit',
+        level: 'error',
+        text: 'error: $message $text',
+      ));
     }
   }
 

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2456,7 +2456,7 @@ class NativePlayer extends PlatformPlayer {
 
   /// Adds an error to the [Player.stream.error].
   void _error(int code) {
-    if (code < 0 && !errorController.isClosed) {
+    if (code < 0 && !errorController.isClosed && code != -8) {
       final message = mpv.mpv_error_string(code).cast<Utf8>().toDartString();
       errorController.add(message);
     }

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -1355,8 +1355,10 @@ class NativePlayer extends PlatformPlayer {
       return;
     }
 
-    _logError(event.ref.error,
-        'event:${event.ref.event_id} ${event.ref.data.cast<Uint8>()}');
+    _logError(
+      event.ref.error,
+      'event:${event.ref.event_id} ${event.ref.data.cast<Uint8>()}',
+    );
 
     if (event.ref.event_id == generated.mpv_event_id.MPV_EVENT_START_FILE) {
       if (isPlayingStateChangeAllowed) {
@@ -2487,14 +2489,14 @@ class NativePlayer extends PlatformPlayer {
       data,
     );
     calloc.free(namePtr);
-    String context = "_setProperty name $name format $format";
+    String text = '_setProperty($name, $format)';
     if (immediate < 0) {
       // Sending failed.
-      _logError(immediate, context);
+      _logError(immediate, text);
       return;
     }
 
-    _logError(await completer.future, context);
+    _logError(await completer.future, text);
   }
 
   Future<void> _setPropertyFlag(String name, bool value) async {
@@ -2554,14 +2556,14 @@ class NativePlayer extends PlatformPlayer {
     final immediate = mpv.mpv_command_async(ctx, requestNumber, arr.cast());
     calloc.free(arr);
     pointers.forEach(calloc.free);
-    String context = "_command ${args.join(" ")}";
+    String text = '_command(${args.join(', ')})';
     if (immediate < 0) {
       // Sending failed.
-      _logError(immediate, context);
+      _logError(immediate, text);
       return;
     }
 
-    _logError(await completer.future, context);
+    _logError(await completer.future, text);
   }
 
   /// Generated libmpv C API bindings.

--- a/media_kit_test/macos/Podfile.lock
+++ b/media_kit_test/macos/Podfile.lock
@@ -43,7 +43,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   media_kit_libs_macos_video: b3e2bbec2eef97c285f2b1baa7963c67c753fb82
   media_kit_video: c75b07f14d59706c775778e4dd47dd027de8d1e5
-  package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
+  package_info_plus: f5790acc797bf17c3e959e9d6cf162cc68ff7523
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   screen_brightness_macos: 2d6d3af2165592d9a55ffcd95b7550970e41ebda
   wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269

--- a/video_player_media_kit/example/macos/Podfile.lock
+++ b/video_player_media_kit/example/macos/Podfile.lock
@@ -11,6 +11,9 @@ PODS:
     - FlutterMacOS
   - screen_brightness_macos (0.1.0):
     - FlutterMacOS
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - wakelock_plus (0.0.1):
     - FlutterMacOS
 
@@ -21,6 +24,7 @@ DEPENDENCIES:
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - screen_brightness_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_brightness_macos/macos`)
+  - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
   - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
 
 EXTERNAL SOURCES:
@@ -36,6 +40,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   screen_brightness_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_brightness_macos/macos
+  video_player_avfoundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
   wakelock_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
@@ -43,11 +49,12 @@ SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   media_kit_libs_macos_video: b3e2bbec2eef97c285f2b1baa7963c67c753fb82
   media_kit_video: c75b07f14d59706c775778e4dd47dd027de8d1e5
-  package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
-  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
+  package_info_plus: f5790acc797bf17c3e959e9d6cf162cc68ff7523
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   screen_brightness_macos: 2d6d3af2165592d9a55ffcd95b7550970e41ebda
+  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
   wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.15.2

--- a/video_player_media_kit/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/video_player_media_kit/example/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/video_player_media_kit/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/video_player_media_kit/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/video_player_media_kit/example/macos/Runner/AppDelegate.swift
+++ b/video_player_media_kit/example/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/video_player_media_kit/lib/src/media_kit_video_player.dart
+++ b/video_player_media_kit/lib/src/media_kit_video_player.dart
@@ -334,12 +334,12 @@ class MediaKitVideoPlayer extends VideoPlayerPlatform {
         player.stream.error.listen(
           (event) async {
             await completer.future;
-            // streamController.addError(
-            //   PlatformException(
-            //     code: '',
-            //     message: event,
-            //   ),
-            // );
+            streamController.addError(
+              PlatformException(
+                code: '',
+                message: event,
+              ),
+            );
           },
         ),
       );

--- a/video_player_media_kit/lib/src/media_kit_video_player.dart
+++ b/video_player_media_kit/lib/src/media_kit_video_player.dart
@@ -334,12 +334,12 @@ class MediaKitVideoPlayer extends VideoPlayerPlatform {
         player.stream.error.listen(
           (event) async {
             await completer.future;
-            streamController.addError(
-              PlatformException(
-                code: '',
-                message: event,
-              ),
-            );
+            // streamController.addError(
+            //   PlatformException(
+            //     code: '',
+            //     message: event,
+            //   ),
+            // );
           },
         ),
       );


### PR DESCRIPTION
i was testing video_player_media_kit to try out the seek without switching fully to media_kit i found out if the error stream throws any error even if its not critical (the sound will play but the video will be black and nothing will work as in ui wise no commands nor streams) but the sound works (so video got loaded correctly )

when i commented that part it works correctly, so i was thinking is it needed and if yes can we limit it to critical errors?