### PR TITLE
fix: pass VideoElement errors as data event to error stream [web]

### DIFF
--- a/media_kit/lib/src/player/web/player/real.dart
+++ b/media_kit/lib/src/player/web/player/real.dart
@@ -238,7 +238,7 @@ class WebPlayer extends PlatformPlayer {
           // PlayerStream.error
           final error = element.error!;
           if (!errorController.isClosed) {
-            errorController.addError(error.message ?? '');
+            errorController.add(error.message ?? '');
           }
         });
       });


### PR DESCRIPTION
VideoElement errors are passed to PlayerStream.error stream as error event instead of data event. Because of this, it becomes inconvenient to handle errors when using web and native.
Closes https://github.com/media-kit/media-kit/issues/991