### PR TITLE
Extracting Mimalloc archive for projects located under folders with spaces in Linux

### DIFF
--- a/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
+++ b/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
@@ -90,7 +90,7 @@ if(NOT MIMALLOC_VALID)
   make_directory("${MIMALLOC_SRC}")
   add_custom_command(
     OUTPUT ${MIMALLOC_LIB}
-    COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${MIMALLOC_ARCHIVE}\""
+    COMMAND "${CMAKE_COMMAND}" -E tar xzf "${MIMALLOC_ARCHIVE}"
 
     # add_subdirectory() is too much work. Alternatively building it through command line.
     COMMAND "mkdir" "-p" "out/release"


### PR DESCRIPTION
Let's say we are under Linux filesystem and we have a Flutter project located under the following path : `/folder1/folder2/folder with spaces/flutter_example` that consumes `media_kit_libs_linux`

If we tried to build the project, an error will be occured :
```
[  +10 ms] cd "/folder1/folder2/folder with spaces/flutter_example/build/linux/x64/release/mimalloc" &&
/usr/local/bin/cmake -E tar xzf "/folder1/folder2/folder\ with\ spaces/flutter_example/build/linux/x64/release/mimalloc-2.1.2.tar.gz" && mkdir -p out/release && cd out/release && /usr/local/bin/cmake ../../mimalloc-2.1.2 && make
[   +1 ms] CMake Error: Problem with archive_read_open_file(): Failed to open
'/folder1/folder2/folder\ with\ spaces/flutter_example/build/linux/x64/release/mimalloc-2.1.2.tar.gz'
[   +4 ms] CMake Error: Problem extracting tar:
/folder1/folder2/folder\ with\ spaces/flutter_example/build/linux/x64/release/mimalloc-2.1.2.tar.gz
```

The problem is located here :
```
cmake -E tar xzf "/folder1/folder2/folder\ with\ spaces/...
```
My fix was to remove the extra "" to make CMake build correctly, given that the special character `\` helps to identify spaces.

Tested on:
- Linux Mint 20.3 (Based on Ubuntu 20.04)
- CMake version 3.25.0-rc1
- Flutter 3.24.3