### PR TITLE
perf: optimize playlist state/stream in `NativePlayer`

### DIFF
--- a/media_kit/lib/src/player/native/core/fallback_bitrate_handler.dart
+++ b/media_kit/lib/src/player/native/core/fallback_bitrate_handler.dart
@@ -7,49 +7,31 @@ import 'dart:io';
 import 'package:uri_parser/uri_parser.dart';
 import 'package:safe_local_storage/safe_local_storage.dart';
 
-/// libmpv doesn't seem to read the bitrate from the files which contain bitrate in their stream metadata (not file metadata).
-/// Typically, I've seen this happening with FLAC & OGG files, since they do not offer the bitrate as a metadata / attached-tags key.
-///
-/// Adding this helper class to calculate the bitrate of the FLAC & OGG files manually. Considering FLAC is a lossless format, this approximation should be fine.
-/// At-least better than the one in libmpv, because it calculates the bitrate from the loaded stream currently in-memory & updates it dynamically as playback progresses.
 abstract class FallbackBitrateHandler {
   static bool supported(String uri) => extractFilePath(uri) != null;
 
   static String? extractFilePath(String uri) {
     try {
-      // Handle local [File] paths.
       final parser = URIParser(uri);
-      switch (parser.type) {
-        case URIType.file:
-          {
-            if (['OGG', 'FLAC'].contains(parser.file!.extension)) {
-              return parser.file!.path;
-            }
-            return null;
-          }
-        // No support for other URI types.
-        default:
-          {
-            return null;
-          }
+      final formats = ['AAC', 'M4A', 'OGG', 'OPUS', 'FLAC'];
+      if (parser.type == URIType.file &&
+          formats.contains(parser.file!.extension)) {
+        return parser.file!.path;
       }
-    } catch (exception) {
-      return null;
-    }
+    } catch (_) {}
+    return null;
   }
 
   static Future<double> calculateBitrate(String uri, Duration duration) async {
     try {
-      final resource = extractFilePath(uri);
-      if (resource != null) {
-        final file = File(resource);
-        final size = await file.length_();
-        final result = size * 8 / duration.inSeconds;
+      final filePath = extractFilePath(uri);
+      if (filePath != null) {
+        final file = File(filePath);
+        final length = await file.length_();
+        final result = length * 8 / duration.inSeconds;
         return result;
       }
-      return 0;
-    } catch (exception) {
-      return 0;
-    }
+    } catch (_) {}
+    return 0;
   }
 }

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -178,8 +178,8 @@ class NativePlayer extends PlatformPlayer {
       await _setPropertyFlag('pause', true);
 
       if (playlist.any((media) => media.uri.startsWith('fd://'))) {
-        // fd:// is used to reference content:// URIs on Android.
-        // The fd:// command does not support this by default, yielding "Refusing to load potentially unsafe URL from a playlist."
+        // The fd:// scheme is used to reference content:// URIs on Android.
+        // The loadlist command does not support this by default, yielding "Refusing to load potentially unsafe URL from a playlist."
         // So, we fallback to loading each file individually.
         for (int i = 0; i < playlist.length; i++) {
           await _command(

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -283,8 +283,10 @@ class NativePlayer extends PlatformPlayer {
         if (!completedController.isClosed) {
           completedController.add(false);
         }
-        if (!positionController.isClosed) {
-          positionController.add(Duration.zero);
+        if (!open) {
+          if (!positionController.isClosed) {
+            positionController.add(Duration.zero);
+          }
         }
         if (!durationController.isClosed) {
           durationController.add(Duration.zero);
@@ -1496,7 +1498,8 @@ class NativePlayer extends PlatformPlayer {
       if (prop.ref.name.cast<Utf8>().toDartString() == 'time-pos' &&
           prop.ref.format == generated.mpv_format.MPV_FORMAT_DOUBLE) {
         final position = Duration(
-            microseconds: prop.ref.data.cast<Double>().value * 1e6 ~/ 1);
+          microseconds: prop.ref.data.cast<Double>().value * 1e6 ~/ 1,
+        );
         state = state.copyWith(position: position);
         if (!positionController.isClosed) {
           positionController.add(position);
@@ -1505,7 +1508,8 @@ class NativePlayer extends PlatformPlayer {
       if (prop.ref.name.cast<Utf8>().toDartString() == 'duration' &&
           prop.ref.format == generated.mpv_format.MPV_FORMAT_DOUBLE) {
         final duration = Duration(
-            microseconds: prop.ref.data.cast<Double>().value * 1e6 ~/ 1);
+          microseconds: prop.ref.data.cast<Double>().value * 1e6 ~/ 1,
+        );
         state = state.copyWith(duration: duration);
         if (!durationController.isClosed) {
           durationController.add(duration);

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2197,10 +2197,7 @@ class NativePlayer extends PlatformPlayer {
               }
             }
           }
-        } catch (exception, stacktrace) {
-          print(exception);
-          print(stacktrace);
-        }
+        } catch (_) {}
         // --------------------------------------------------
         mpv.mpv_hook_continue(
           ctx,

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -160,6 +160,15 @@ class NativePlayer extends PlatformPlayer {
       // Keep these [Media] objects in memory.
       current = playlist;
 
+      // External List<Media>:
+      // ---------------------------------------------
+      final playlistState = Playlist(playlist, index: index);
+      state = state.copyWith(playlist: playlistState);
+      if (!playlistController.isClosed) {
+        playlistController.add(playlistState);
+      }
+      // ---------------------------------------------
+
       // Restore original state & reset public [PlayerState] & [PlayerStream] values e.g. width=null, height=null, subtitle=['', ''] etc.
       await stop(
         open: true,
@@ -170,10 +179,9 @@ class NativePlayer extends PlatformPlayer {
       await _setPropertyFlag('pause', true);
 
       if (playlist.any((media) => media.uri.startsWith('fd://'))) {
-        // `fd://` is a scheme used to reference `content` URIs on Android,
-        // but the `loadlist` command does not support that scheme by default,
-        // yielding "Refusing to load potentially unsafe URL from a playlist."
-        // so we fallback to loading each file individually.
+        // fd:// is used to reference content:// URIs on Android.
+        // The fd:// command does not support this by default, yielding "Refusing to load potentially unsafe URL from a playlist."
+        // So, we fallback to loading each file individually.
         for (int i = 0; i < playlist.length; i++) {
           await _command(
             [

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -461,7 +461,8 @@ class NativePlayer extends PlatformPlayer {
 
       // External List<Media>:
       // ---------------------------------------------
-      current.add(media);
+      // Force a new List<T> object.
+      current = [...current, media];
       final playlist = state.playlist.copyWith(medias: current);
       state = state.copyWith(playlist: playlist);
       if (!playlistController.isClosed) {
@@ -491,6 +492,8 @@ class NativePlayer extends PlatformPlayer {
 
       // External List<Media>:
       // ---------------------------------------------
+      // Force a new List<T> object.
+      current = [...current];
       current.removeAt(index);
       final playlist = state.playlist.copyWith(medias: current);
       state = state.copyWith(playlist: playlist);

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -162,10 +162,9 @@ class NativePlayer extends PlatformPlayer {
 
       // External List<Media>:
       // ---------------------------------------------
-      final playlistState = Playlist(playlist, index: index);
-      state = state.copyWith(playlist: playlistState);
+      state = state.copyWith(playlist: Playlist(playlist, index: index));
       if (!playlistController.isClosed) {
-        playlistController.add(playlistState);
+        playlistController.add(Playlist(playlist, index: index));
       }
       // ---------------------------------------------
 
@@ -777,9 +776,7 @@ class NativePlayer extends PlatformPlayer {
       if (configuration.pitch) {
         // Pitch shift control is enabled.
 
-        state = state.copyWith(
-          rate: rate,
-        );
+        state = state.copyWith(rate: rate);
         if (!rateController.isClosed) {
           rateController.add(state.rate);
         }
@@ -793,9 +790,7 @@ class NativePlayer extends PlatformPlayer {
       } else {
         // Pitch shift control is disabled.
 
-        state = state.copyWith(
-          rate: rate,
-        );
+        state = state.copyWith(rate: rate);
         if (!rateController.isClosed) {
           rateController.add(state.rate);
         }
@@ -831,9 +826,7 @@ class NativePlayer extends PlatformPlayer {
 
         // Pitch shift control is enabled.
 
-        state = state.copyWith(
-          pitch: pitch,
-        );
+        state = state.copyWith(pitch: pitch);
         if (!pitchController.isClosed) {
           pitchController.add(state.pitch);
         }
@@ -1539,10 +1532,11 @@ class NativePlayer extends PlatformPlayer {
         }
       }
       if (prop.ref.name.cast<Utf8>().toDartString() == 'playlist-playing-pos' &&
-          prop.ref.format == generated.mpv_format.MPV_FORMAT_INT64) {
+          prop.ref.format == generated.mpv_format.MPV_FORMAT_INT64 &&
+          prop.ref.data != nullptr) {
         final index = prop.ref.data.cast<Int64>().value;
-        if (index > 0) {
-          final playlist = state.playlist.copyWith(index: index);
+        if (index >= 0) {
+          final playlist = Playlist(current, index: index);
           state = state.copyWith(playlist: playlist);
           if (!playlistController.isClosed) {
             playlistController.add(playlist);

--- a/media_kit/lib/src/player/native/utils/native_reference_holder.dart
+++ b/media_kit/lib/src/player/native/utils/native_reference_holder.dart
@@ -12,6 +12,7 @@ import 'package:synchronized/synchronized.dart';
 
 import 'package:media_kit/ffi/src/allocation.dart';
 import 'package:media_kit/src/player/native/utils/temp_file.dart';
+import 'package:media_kit/src/values.dart';
 
 /// Callback invoked to notify about the released references.
 typedef NativeReferenceHolderCallback = void Function(List<Pointer<Void>>);
@@ -27,15 +28,6 @@ typedef NativeReferenceHolderCallback = void Function(List<Pointer<Void>>);
 class NativeReferenceHolder {
   /// Maximum number of references that can be held.
   static const int kReferenceBufferSize = 512;
-
-  // Ref:
-  // https://api.flutter.dev/flutter/foundation/kReleaseMode-constant.html
-  // https://api.flutter.dev/flutter/foundation/kProfileMode-constant.html
-  // https://api.flutter.dev/flutter/foundation/kDebugMode-constant.html
-
-  static const bool kReleaseMode = bool.fromEnvironment('dart.vm.product');
-  static const bool kProfileMode = bool.fromEnvironment('dart.vm.profile');
-  static const bool kDebugMode = !kReleaseMode && !kProfileMode;
 
   /// Singleton instance.
   static final NativeReferenceHolder instance = NativeReferenceHolder._();

--- a/media_kit/lib/src/values.dart
+++ b/media_kit/lib/src/values.dart
@@ -6,3 +6,9 @@
 
 /// A constant that is true if the application was compiled in release mode.
 const bool kReleaseMode = bool.fromEnvironment('dart.vm.product');
+
+/// A constant that is true if the application was compiled in profile mode.
+const bool kProfileMode = bool.fromEnvironment('dart.vm.profile');
+
+/// A constant that is true if the application was compiled in debug mode.
+const bool kDebugMode = !kReleaseMode && !kProfileMode;

--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -623,7 +623,6 @@ void main() {
         },
       );
 
-      int i = 0;
       final expectPosition = expectAsync1(
         (value) {
           print(value);
@@ -631,16 +630,8 @@ void main() {
           expect(value, isA<Duration>());
           final position = value as Duration;
 
-          if (i == 0) {
-            expect(position, Duration.zero);
-          } else if (i == 1) {
-            expect(position, const Duration(seconds: 2));
-          } else {
-            expect(position, greaterThan(const Duration(seconds: 2)));
-            expect(position, lessThanOrEqualTo(const Duration(seconds: 5)));
-          }
-
-          i++;
+          expect(position, greaterThanOrEqualTo(const Duration(seconds: 2)));
+          expect(position, lessThanOrEqualTo(const Duration(seconds: 5)));
         },
         count: 1,
         max: -1,

--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -704,7 +704,6 @@ void main() {
             expectEnd(e.medias[e.index].end, e.index);
 
             // Check for position updates of this [Media].
-            int i = 0;
             final expectPosition = expectAsync1(
               (value) {
                 print(value);
@@ -712,14 +711,14 @@ void main() {
                 expect(value, isA<Duration>());
                 final position = value as Duration;
 
-                if (i == 0) {
-                  expect(position, e.medias[e.index].start);
-                } else {
-                  expect(position, greaterThan(e.medias[e.index].start!));
-                  expect(position, lessThanOrEqualTo(e.medias[e.index].end!));
-                }
-
-                i++;
+                expect(
+                  position,
+                  greaterThanOrEqualTo(e.medias[e.index].start!),
+                );
+                expect(
+                  position,
+                  lessThanOrEqualTo(e.medias[e.index].end!),
+                );
               },
               count: 1,
               max: -1,

--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -644,7 +644,14 @@ void main() {
         }
       });
 
+      bool opened = false;
+
       player.stream.position.listen((e) {
+        if (!opened) {
+          // Emits Duration.zero right after open(...).
+          opened = true;
+          return;
+        }
         expectPosition(e);
       });
 
@@ -688,6 +695,8 @@ void main() {
 
       StreamSubscription<Duration>? subscription;
 
+      bool opened = false;
+
       player.stream.playlist.listen(
         (e) {
           if (e.index >= 0) {
@@ -697,6 +706,12 @@ void main() {
             // Check for position updates of this [Media].
             final expectPosition = expectAsync1(
               (value) {
+                if (!opened) {
+                  // Emits Duration.zero right after open(...).
+                  opened = true;
+                  return;
+                }
+
                 print(value);
 
                 expect(value, isA<Duration>());


### PR DESCRIPTION
It is too expensive to iterate through returned `mpv_node*`.