### PR TITLE
fix: pass http headers to hls.js

### DIFF
--- a/media_kit/lib/src/models/media/media_web.dart
+++ b/media_kit/lib/src/models/media/media_web.dart
@@ -90,11 +90,6 @@ class Media extends Playable {
         extras = extras ?? cache[normalizeURI(resource)]?.extras,
         httpHeaders =
             httpHeaders ?? cache[normalizeURI(resource)]?.httpHeaders {
-    // Ensure httpHeaders are not null or empty to prevent using unsupported HTTP headers on the web
-    // if (httpHeaders != null && httpHeaders.isNotEmpty) {
-    //   throw UnsupportedError('HTTP headers are not supported on web');
-    // }
-
     // Increment reference count.
     ref[uri] = ((ref[uri] ?? 0) + 1).clamp(0, 1 << 32);
     // Store [this] instance in [cache].

--- a/media_kit/lib/src/models/media/media_web.dart
+++ b/media_kit/lib/src/models/media/media_web.dart
@@ -91,9 +91,9 @@ class Media extends Playable {
         httpHeaders =
             httpHeaders ?? cache[normalizeURI(resource)]?.httpHeaders {
     // Ensure httpHeaders are not null or empty to prevent using unsupported HTTP headers on the web
-    if (httpHeaders != null && httpHeaders.isNotEmpty) {
-      throw UnsupportedError('HTTP headers are not supported on web');
-    }
+    // if (httpHeaders != null && httpHeaders.isNotEmpty) {
+    //   throw UnsupportedError('HTTP headers are not supported on web');
+    // }
 
     // Increment reference count.
     ref[uri] = ((ref[uri] ?? 0) + 1).clamp(0, 1 << 32);

--- a/media_kit/lib/src/player/web/player/real.dart
+++ b/media_kit/lib/src/player/web/player/real.dart
@@ -1415,7 +1415,19 @@ class WebPlayer extends PlatformPlayer {
   void _loadSource(Media media) {
     try {
       if (_isHLS(media.uri)) {
-        final hls = Hls();
+        void setHlsHTTPHeaders(html.HttpRequest xhr) {
+          for (final header in media.httpHeaders!.entries) {
+            xhr.setRequestHeader(header.key, header.value);
+          }
+        }
+
+        final hls = Hls(
+          media.httpHeaders != null
+              ? HlsOptions(
+                  xhrSetup: js.allowInterop(setHlsHTTPHeaders),
+                )
+              : null,
+        );
         hls.loadSource(media.uri);
         hls.attachMedia(element);
       } else {

--- a/media_kit/lib/src/player/web/player/real.dart
+++ b/media_kit/lib/src/player/web/player/real.dart
@@ -1415,19 +1415,20 @@ class WebPlayer extends PlatformPlayer {
   void _loadSource(Media media) {
     try {
       if (_isHLS(media.uri)) {
-        void setHlsHTTPHeaders(html.HttpRequest xhr) {
+        void setHlsHTTPHeaders(html.HttpRequest xhr, String url) {
           for (final header in media.httpHeaders!.entries) {
             xhr.setRequestHeader(header.key, header.value);
           }
         }
 
         final hls = Hls(
-          media.httpHeaders != null
-              ? HlsOptions(
-                  xhrSetup: js.allowInterop(setHlsHTTPHeaders),
-                )
-              : null,
+          HlsOptions(
+            xhrSetup: media.httpHeaders != null
+                ? js.allowInterop(setHlsHTTPHeaders)
+                : null,
+          ),
         );
+
         hls.loadSource(media.uri);
         hls.attachMedia(element);
       } else {

--- a/media_kit/lib/src/player/web/utils/hls.dart
+++ b/media_kit/lib/src/player/web/utils/hls.dart
@@ -81,14 +81,15 @@ external bool isHLSSupported();
 @js.JS()
 @js.anonymous
 class HlsOptions {
-  external void Function(html.HttpRequest xhr) get xhrSetup;
-  external factory HlsOptions({void Function(html.HttpRequest xhr) xhrSetup});
+  external factory HlsOptions({
+    void Function(html.HttpRequest xhr, String url)? xhrSetup,
+  });
 }
 
 @js.JS()
 @js.staticInterop
 class Hls {
-  external factory Hls(HlsOptions? options);
+  external factory Hls(HlsOptions options);
 }
 
 extension ExtensionHls on Hls {

--- a/media_kit/lib/src/player/web/utils/hls.dart
+++ b/media_kit/lib/src/player/web/utils/hls.dart
@@ -79,9 +79,16 @@ abstract class HLS {
 external bool isHLSSupported();
 
 @js.JS()
+@js.anonymous
+class HlsOptions {
+  external void Function(html.HttpRequest xhr) get xhrSetup;
+  external factory HlsOptions({void Function(html.HttpRequest xhr) xhrSetup});
+}
+
+@js.JS()
 @js.staticInterop
 class Hls {
-  external factory Hls();
+  external factory Hls(HlsOptions? options);
 }
 
 extension ExtensionHls on Hls {


### PR DESCRIPTION
Use the xhrSetup option in hls.js to set the http headers for media when on the web.

Fixes https://github.com/media-kit/media-kit/issues/1042

Things used:
- https://github.com/video-dev/hls.js/blob/master/docs/API.md#xhrsetup