### PR TITLE
fix: Fix playlist loading performances

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -192,10 +192,11 @@ class NativePlayer extends PlatformPlayer {
         }
       } else {
         final file = await TempFile.create();
-        String list = '';
+        final buffer = StringBuffer();
         for (final media in playlist) {
-          list += '${media.uri}\n';
+          buffer.writeln(media.uri);
         }
+        final list = buffer.toString();
 
         await file.write_(list);
 


### PR DESCRIPTION
When the playlist is big it takes a lot of time to load it. For example, on a Pixel 5, it takes 1200ms to open a playlist with ~6000 medias causing an UI freeze. By simply replacing the current loop with a StringBuilder it only takes around 100ms which is 10 times faster