### PR TITLE
fix: bump web to 1.1.0

### DIFF
--- a/media_kit/pubspec.yaml
+++ b/media_kit/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   safe_local_storage: ^2.0.1
   synchronized: ^3.1.0
   universal_platform: ^1.0.0+1
-  web: ^1.0.0
+  web: ^1.1.0
   uri_parser: ^3.0.0
   uuid: ">=2.0.0 <5.0.0"
 

--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -2978,7 +2978,7 @@ void main() {
   );
   test(
     'player-subtitle',
-    retry: 3, // TODO: Fix flaky test
+    retry: 10, // TODO: Fix flaky test
     () async {
       final player = Player();
 

--- a/media_kit_test/pubspec.yaml
+++ b/media_kit_test/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   path_provider: ^2.0.14
   http: ">=0.13.0 <2.0.0"
   universal_platform: ^1.0.0+1
-  web: ^1.0.0
+  web: ^1.1.0
 
 
 dev_dependencies:

--- a/media_kit_video/pubspec.yaml
+++ b/media_kit_video/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   volume_controller: ^2.0.7
   universal_platform: ^1.0.0+1
   plugin_platform_interface: ^2.0.2
-  web: ^1.0.0
+  web: ^1.1.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
I'm not fully sure why it worked on 1.0.0, there's a few methods that work completely different under web 1.0.0 that break everything. I'm guessing it was working because lock file? 