### PR TITLE
Fix: improve responsiveness of showing controls on mobile

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -768,18 +768,6 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
   }
 
   void _handlePointerDown(PointerDownEvent event) {
-    if (!(_isInCenterSegment(event.position.dx))) {
-      return;
-    }
-
-    onTap();
-  }
-
-  void _handleTapDown(TapDownDetails details) {
-    if ((_isInCenterSegment(details.localPosition.dx))) {
-      return;
-    }
-
     onTap();
   }
 
@@ -924,7 +912,6 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                       child: Listener(
                         onPointerDown: (event) => _handlePointerDown(event),
                         child: GestureDetector(
-                          onTapDown: (details) => _handleTapDown(details),
                           onDoubleTapDown: _handleDoubleTapDown,
                           onLongPress: _theme(context).speedUpOnLongPress
                               ? _handleLongPress


### PR DESCRIPTION
this makes the controls come up in instant instead of the sides being slow due to waiting for double tap without breaking double tap