### PR TITLE
fix: add null checks for uri and textureId in MediaKitVideoPlayer

### DIFF
--- a/video_player_media_kit/lib/src/media_kit_video_player.dart
+++ b/video_player_media_kit/lib/src/media_kit_video_player.dart
@@ -103,6 +103,9 @@ class MediaKitVideoPlayer extends VideoPlayerPlatform {
       case DataSourceType.network:
       case DataSourceType.file:
       case DataSourceType.contentUri:
+        if (dataSource.uri == null) {
+          throw ArgumentError('uri must not be null');
+        }
         resource = dataSource.uri!;
         break;
 
@@ -124,6 +127,10 @@ class MediaKitVideoPlayer extends VideoPlayerPlatform {
   /// Returns a Stream of [VideoEventType]s.
   @override
   Stream<VideoEvent> videoEventsFor(int textureId) {
+    if (_streamControllers[textureId] == null) {
+      throw StateError(
+          'VideoPlayer for textureId $textureId is not found, Check if its disposed.');
+    }
     return _streamControllers[textureId]!.stream;
   }
 
@@ -174,6 +181,10 @@ class MediaKitVideoPlayer extends VideoPlayerPlatform {
   /// Returns a widget displaying the video with a given textureId.
   @override
   Widget buildView(int textureId) {
+    if (_videoControllers[textureId] == null) {
+      throw StateError(
+          'VideoPlayer for textureId $textureId is not found, Check if its disposed.');
+    }
     return Video(
       key: ValueKey(_videoControllers[textureId]!),
       controller: _videoControllers[textureId]!,


### PR DESCRIPTION
related to this issue https://github.com/media-kit/media-kit/issues/1064 just improving developer experience 