### PR TITLE
fix: replace `EdgeInsets` with `EdgeInsetsGeometry`

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/extensions/padding.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/extensions/padding.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+
+extension EdgeInsetsGeometryExt on EdgeInsetsGeometry? {
+  double get bottom {
+    final value = this;
+
+    if (value == null) return 0.0;
+    if (value is EdgeInsets) return value.bottom;
+    if (value is EdgeInsetsDirectional) return value.bottom;
+
+    return 0.0;
+  }
+
+  double get top {
+    final value = this;
+    if (value == null) return 0.0;
+    if (value is EdgeInsets) return value.top;
+    if (value is EdgeInsetsDirectional) return value.top;
+
+    return 0.0;
+  }
+
+  double get start {
+    final value = this;
+    if (value == null) return 0.0;
+    if (value is EdgeInsets) return value.left;
+    if (value is EdgeInsetsDirectional) return value.start;
+
+    return 0.0;
+  }
+
+  double get end {
+    final value = this;
+    if (value == null) return 0.0;
+    if (value is EdgeInsets) return value.right;
+    if (value is EdgeInsetsDirectional) return value.end;
+
+    return 0.0;
+  }
+}

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -192,7 +192,7 @@ class MaterialVideoControlsThemeData {
   /// * FullScreen: `MediaQuery.of(context).padding`
   ///
   /// NOTE: In fullscreen, this will be safe area (set [padding] to [EdgeInsets.zero] to disable safe area)
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
 
   /// [Duration] after which the controls will be hidden when there is no mouse movement.
   final Duration controlsHoverDuration;
@@ -224,13 +224,13 @@ class MaterialVideoControlsThemeData {
   final List<Widget> topButtonBar;
 
   /// Margin around the top button bar.
-  final EdgeInsets topButtonBarMargin;
+  final EdgeInsetsGeometry topButtonBarMargin;
 
   /// Buttons to be displayed in the bottom button bar.
   final List<Widget> bottomButtonBar;
 
   /// Margin around the button bar.
-  final EdgeInsets bottomButtonBarMargin;
+  final EdgeInsetsGeometry bottomButtonBarMargin;
 
   /// Height of the button bar.
   final double buttonBarHeight;
@@ -244,7 +244,7 @@ class MaterialVideoControlsThemeData {
   // SEEK BAR
 
   /// Margin around the seek bar.
-  final EdgeInsets seekBarMargin;
+  final EdgeInsetsGeometry seekBarMargin;
 
   /// Height of the seek bar.
   final double seekBarHeight;
@@ -366,13 +366,13 @@ class MaterialVideoControlsThemeData {
     Widget Function(BuildContext, double)? speedUpIndicatorBuilder,
     List<Widget>? primaryButtonBar,
     List<Widget>? topButtonBar,
-    EdgeInsets? topButtonBarMargin,
+    EdgeInsetsGeometry? topButtonBarMargin,
     List<Widget>? bottomButtonBar,
-    EdgeInsets? bottomButtonBarMargin,
+    EdgeInsetsGeometry? bottomButtonBarMargin,
     double? buttonBarHeight,
     double? buttonBarButtonSize,
     Color? buttonBarButtonColor,
-    EdgeInsets? seekBarMargin,
+    EdgeInsetsGeometry? seekBarMargin,
     double? seekBarHeight,
     double? seekBarContainerHeight,
     Color? seekBarColor,

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 import 'package:media_kit_video/media_kit_video_controls/src/controls/extensions/duration.dart';
+import 'package:media_kit_video/media_kit_video_controls/src/controls/extensions/padding.dart';
 import 'package:media_kit_video/media_kit_video_controls/src/controls/methods/video_state.dart';
 import 'package:media_kit_video/media_kit_video_controls/src/controls/widgets/video_controls_theme_data_injector.dart';
 import 'package:screen_brightness_platform_interface/screen_brightness_platform_interface.dart';
@@ -631,14 +632,15 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
 
   void shiftSubtitle() {
     if (_theme(context).shiftSubtitlesOnControlsVisibilityChange) {
+      final configPadding =
+          state(context).widget.subtitleViewConfiguration.padding;
       state(context).setSubtitleViewPadding(
-        state(context).widget.subtitleViewConfiguration.padding +
-            EdgeInsets.fromLTRB(
-              0.0,
-              0.0,
-              0.0,
-              subtitleVerticalShiftOffset,
-            ),
+        EdgeInsets.fromLTRB(
+          configPadding.start,
+          configPadding.top,
+          configPadding.end,
+          configPadding.bottom + subtitleVerticalShiftOffset,
+        ),
       );
     }
   }

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:media_kit_video/media_kit_video.dart';
+import 'package:media_kit_video/media_kit_video_controls/src/controls/extensions/padding.dart';
 
 import 'package:media_kit_video/media_kit_video_controls/src/controls/methods/video_state.dart';
 import 'package:media_kit_video/media_kit_video_controls/src/controls/extensions/duration.dart';
@@ -449,15 +450,15 @@ class _MaterialDesktopVideoControlsState
 
   void shiftSubtitle() {
     if (_theme(context).shiftSubtitlesOnControlsVisibilityChange) {
-      state(context).setSubtitleViewPadding(
-        state(context).widget.subtitleViewConfiguration.padding +
-            EdgeInsets.fromLTRB(
-              0.0,
-              0.0,
-              0.0,
-              subtitleVerticalShiftOffset,
-            ),
-      );
+      final configPadding =
+          state(context).widget.subtitleViewConfiguration.padding;
+
+      state(context).setSubtitleViewPadding(EdgeInsets.fromLTRB(
+        configPadding.start,
+        configPadding.top,
+        configPadding.end,
+        configPadding.bottom + subtitleVerticalShiftOffset,
+      ));
     }
   }
 

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -82,7 +82,7 @@ class MaterialDesktopVideoControlsThemeData {
   ///
   /// * Default: `EdgeInsets.zero`
   /// * Fullscreen: `MediaQuery.of(context).padding`
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
 
   /// [Duration] after which the controls will be hidden when there is no mouse movement.
   final Duration controlsHoverDuration;
@@ -102,13 +102,13 @@ class MaterialDesktopVideoControlsThemeData {
   final List<Widget> topButtonBar;
 
   /// Margin around the top button bar.
-  final EdgeInsets topButtonBarMargin;
+  final EdgeInsetsGeometry topButtonBarMargin;
 
   /// Buttons to be displayed in the bottom button bar.
   final List<Widget> bottomButtonBar;
 
   /// Margin around the bottom button bar.
-  final EdgeInsets bottomButtonBarMargin;
+  final EdgeInsetsGeometry bottomButtonBarMargin;
 
   /// Height of the button bar.
   final double buttonBarHeight;
@@ -128,7 +128,7 @@ class MaterialDesktopVideoControlsThemeData {
   final Duration seekBarThumbTransitionDuration;
 
   /// Margin around the seek bar.
-  final EdgeInsets seekBarMargin;
+  final EdgeInsetsGeometry seekBarMargin;
 
   /// Height of the seek bar.
   final double seekBarHeight;
@@ -245,15 +245,15 @@ class MaterialDesktopVideoControlsThemeData {
     Duration? controlsTransitionDuration,
     Widget Function(BuildContext)? bufferingIndicatorBuilder,
     List<Widget>? topButtonBar,
-    EdgeInsets? topButtonBarMargin,
+    EdgeInsetsGeometry? topButtonBarMargin,
     List<Widget>? bottomButtonBar,
-    EdgeInsets? bottomButtonBarMargin,
+    EdgeInsetsGeometry? bottomButtonBarMargin,
     double? buttonBarHeight,
     double? buttonBarButtonSize,
     Color? buttonBarButtonColor,
     Duration? seekBarTransitionDuration,
     Duration? seekBarThumbTransitionDuration,
-    EdgeInsets? seekBarMargin,
+    EdgeInsetsGeometry? seekBarMargin,
     double? seekBarHeight,
     double? seekBarHoverHeight,
     double? seekBarContainerHeight,

--- a/media_kit_video/lib/src/subtitle/subtitle_view.dart
+++ b/media_kit_video/lib/src/subtitle/subtitle_view.dart
@@ -37,7 +37,7 @@ class SubtitleView extends StatefulWidget {
 
 class SubtitleViewState extends State<SubtitleView> {
   late List<String> subtitle = widget.controller.player.state.subtitle;
-  late EdgeInsets padding = widget.configuration.padding;
+  late EdgeInsetsGeometry padding = widget.configuration.padding;
   late Duration duration = const Duration(milliseconds: 100);
 
   // The [StreamSubscription] to listen to the subtitle changes.
@@ -68,7 +68,7 @@ class SubtitleViewState extends State<SubtitleView> {
   ///
   /// The [duration] argument may be specified to set the duration of the animation.
   void setPadding(
-    EdgeInsets padding, {
+    EdgeInsetsGeometry padding, {
     Duration duration = const Duration(milliseconds: 100),
   }) {
     if (this.duration != duration) {
@@ -137,7 +137,7 @@ class SubtitleViewConfiguration {
   final TextScaler? textScaler;
 
   /// The padding to be used for the subtitles.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// {@macro subtitle_view_configuration}
   const SubtitleViewConfiguration({

--- a/media_kit_video/lib/src/video/video_texture.dart
+++ b/media_kit_video/lib/src/video/video_texture.dart
@@ -167,7 +167,7 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
   }
 
   void setSubtitleViewPadding(
-    EdgeInsets padding, {
+    EdgeInsetsGeometry padding, {
     Duration duration = const Duration(milliseconds: 100),
   }) {
     return _subtitleViewKey.currentState?.setPadding(

--- a/media_kit_video/lib/src/video/video_web.dart
+++ b/media_kit_video/lib/src/video/video_web.dart
@@ -168,7 +168,7 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
   }
 
   void setSubtitleViewPadding(
-    EdgeInsets padding, {
+    EdgeInsetsGeometry padding, {
     Duration duration = const Duration(milliseconds: 100),
   }) {
     return _subtitleViewKey.currentState?.setPadding(


### PR DESCRIPTION
Hello & Happy New Year.

I have just started using your package, and we are giving the RTL support on our app. The `media_kit` package does not behave well with RTL since does not use a general interface, EdgeInsetsGeometry.

This change should not change any behavior. It only changes the interface
