### PR TITLE
Remove unused js dependency

### DIFF
--- a/media_kit/pubspec.yaml
+++ b/media_kit/pubspec.yaml
@@ -35,7 +35,6 @@ dependencies:
   collection: ^1.17.0
   http: ">=0.13.0 <2.0.0"
   image: ^4.0.17
-  js: ^0.7.1
   meta: ^1.8.0
   path: ^1.8.0
   safe_local_storage: ^2.0.1

--- a/media_kit_test/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/media_kit_test/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,16 +5,20 @@
 import FlutterMacOS
 import Foundation
 
+import file_picker
 import media_kit_libs_macos_video
 import media_kit_video
 import package_info_plus
 import path_provider_foundation
+import volume_controller
 import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  VolumeControllerPlugin.register(with: registry.registrar(forPlugin: "VolumeControllerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/media_kit_test/windows/flutter/generated_plugin_registrant.cc
+++ b/media_kit_test/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
+#include <volume_controller/volume_controller_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   MediaKitVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitVideoPluginCApi"));
+  VolumeControllerPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("VolumeControllerPluginCApi"));
 }

--- a/media_kit_test/windows/flutter/generated_plugins.cmake
+++ b/media_kit_test/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_libs_windows_video
   media_kit_video
+  volume_controller
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/video_player_media_kit/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/video_player_media_kit/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import media_kit_video
 import package_info_plus
 import path_provider_foundation
 import video_player_avfoundation
+import volume_controller
 import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -18,5 +19,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
+  VolumeControllerPlugin.register(with: registry.registrar(forPlugin: "VolumeControllerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/video_player_media_kit/example/windows/flutter/generated_plugin_registrant.cc
+++ b/video_player_media_kit/example/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
+#include <volume_controller/volume_controller_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   MediaKitVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitVideoPluginCApi"));
+  VolumeControllerPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("VolumeControllerPluginCApi"));
 }

--- a/video_player_media_kit/example/windows/flutter/generated_plugins.cmake
+++ b/video_player_media_kit/example/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_libs_windows_video
   media_kit_video
+  volume_controller
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
# Issue
Keeping JS imported conflicts with other packages. This is not longer used.

Fixes https://github.com/media-kit/media-kit/issues/1127