### PR TITLE
feat: Add FocusNode support for video controls and parameters

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -865,10 +865,12 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
         splashColor: const Color(0x00000000),
         highlightColor: const Color(0x00000000),
       ),
+
       /// Add [Directionality] to ltr to avoid wrong animation of sides.
       child: Directionality(
         textDirection: TextDirection.ltr,
         child: Focus(
+          focusNode: videoViewParametersNotifier(context).value.focusNode,
           autofocus: true,
           child: Material(
             elevation: 0.0,

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -575,6 +575,7 @@ class _MaterialDesktopVideoControlsState
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Focus(
+            focusNode: videoViewParametersNotifier(context).value.focusNode,
             autofocus: true,
             child: Material(
               elevation: 0.0,

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart
@@ -69,6 +69,8 @@ Future<void> enterFullscreen(BuildContext context) {
                         subtitleViewConfiguration:
                             videoViewParametersNotifierValue
                                 .value.subtitleViewConfiguration,
+                        focusNode: videoViewParametersNotifierValue.value
+                            .focusNode,
                         onEnterFullscreen: stateValue.widget.onEnterFullscreen,
                         onExitFullscreen: stateValue.widget.onExitFullscreen,
                       ),

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart
@@ -69,8 +69,8 @@ Future<void> enterFullscreen(BuildContext context) {
                         subtitleViewConfiguration:
                             videoViewParametersNotifierValue
                                 .value.subtitleViewConfiguration,
-                        focusNode: videoViewParametersNotifierValue.value
-                            .focusNode,
+                        focusNode:
+                            videoViewParametersNotifierValue.value.focusNode,
                         onEnterFullscreen: stateValue.widget.onEnterFullscreen,
                         onExitFullscreen: stateValue.widget.onExitFullscreen,
                       ),

--- a/media_kit_video/lib/src/video/video_texture.dart
+++ b/media_kit_video/lib/src/video/video_texture.dart
@@ -113,6 +113,9 @@ class Video extends StatefulWidget {
   /// The callback invoked when the [Video] exits fullscreen.
   final Future<void> Function() onExitFullscreen;
 
+  /// FocusNode for keyboard input.
+  final FocusNode? focusNode;
+
   /// {@macro video}
   const Video({
     Key? key,
@@ -131,6 +134,7 @@ class Video extends StatefulWidget {
     this.subtitleViewConfiguration = const SubtitleViewConfiguration(),
     this.onEnterFullscreen = defaultEnterNativeFullscreen,
     this.onExitFullscreen = defaultExitNativeFullscreen,
+    this.focusNode,
   }) : super(key: key);
 
   @override
@@ -186,19 +190,20 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
     FilterQuality? filterQuality,
     VideoControlsBuilder? controls,
     SubtitleViewConfiguration? subtitleViewConfiguration,
+    FocusNode? focusNode,
   }) {
-    videoViewParametersNotifier.value =
-        videoViewParametersNotifier.value.copyWith(
-      width: width,
-      height: height,
-      fit: fit,
-      fill: fill,
-      alignment: alignment,
-      aspectRatio: aspectRatio,
-      filterQuality: filterQuality,
-      controls: controls,
-      subtitleViewConfiguration: subtitleViewConfiguration,
-    );
+    videoViewParametersNotifier.value = videoViewParametersNotifier.value
+        .copyWith(
+            width: width,
+            height: height,
+            fit: fit,
+            fill: fill,
+            alignment: alignment,
+            aspectRatio: aspectRatio,
+            filterQuality: filterQuality,
+            controls: controls,
+            subtitleViewConfiguration: subtitleViewConfiguration,
+            focusNode: focusNode);
   }
 
   @override
@@ -218,6 +223,7 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
                 filterQuality: widget.filterQuality,
                 controls: widget.controls,
                 subtitleViewConfiguration: widget.subtitleViewConfiguration,
+                focusNode: widget.focusNode,
               ),
             );
     _disposeNotifiers =
@@ -258,6 +264,9 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
               oldWidget.subtitleViewConfiguration
           ? widget.subtitleViewConfiguration
           : currentParams.subtitleViewConfiguration,
+      focusNode: widget.focusNode != oldWidget.focusNode
+          ? widget.focusNode
+          : currentParams.focusNode,
     );
 
     if (newParams != currentParams) {
@@ -421,8 +430,8 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
                                                 rect.height <= 1.0)
                                               Positioned.fill(
                                                 child: Container(
-                                                  color:
-                                                      videoViewParameters.fill,
+                                                  color: videoViewParameters
+                                                      .fill,
                                                 ),
                                               ),
                                           ],
@@ -438,7 +447,8 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
                   ),
                 ),
                 if (videoViewParameters.subtitleViewConfiguration.visible &&
-                    !(widget.controller.player.platform?.configuration.libass ??
+                    !(widget.controller.player.platform?.configuration
+                            .libass ??
                         false))
                   Positioned.fill(
                     child: SubtitleView(

--- a/media_kit_video/lib/src/video/video_texture.dart
+++ b/media_kit_video/lib/src/video/video_texture.dart
@@ -192,18 +192,19 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
     SubtitleViewConfiguration? subtitleViewConfiguration,
     FocusNode? focusNode,
   }) {
-    videoViewParametersNotifier.value = videoViewParametersNotifier.value
-        .copyWith(
-            width: width,
-            height: height,
-            fit: fit,
-            fill: fill,
-            alignment: alignment,
-            aspectRatio: aspectRatio,
-            filterQuality: filterQuality,
-            controls: controls,
-            subtitleViewConfiguration: subtitleViewConfiguration,
-            focusNode: focusNode);
+    videoViewParametersNotifier.value =
+        videoViewParametersNotifier.value.copyWith(
+      width: width,
+      height: height,
+      fit: fit,
+      fill: fill,
+      alignment: alignment,
+      aspectRatio: aspectRatio,
+      filterQuality: filterQuality,
+      controls: controls,
+      subtitleViewConfiguration: subtitleViewConfiguration,
+      focusNode: focusNode,
+    );
   }
 
   @override
@@ -430,8 +431,8 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
                                                 rect.height <= 1.0)
                                               Positioned.fill(
                                                 child: Container(
-                                                  color: videoViewParameters
-                                                      .fill,
+                                                  color:
+                                                      videoViewParameters.fill,
                                                 ),
                                               ),
                                           ],
@@ -447,8 +448,7 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
                   ),
                 ),
                 if (videoViewParameters.subtitleViewConfiguration.visible &&
-                    !(widget.controller.player.platform?.configuration
-                            .libass ??
+                    !(widget.controller.player.platform?.configuration.libass ??
                         false))
                   Positioned.fill(
                     child: SubtitleView(

--- a/media_kit_video/lib/src/video/video_web.dart
+++ b/media_kit_video/lib/src/video/video_web.dart
@@ -383,77 +383,72 @@ class VideoState extends State<Video> with WidgetsBindingObserver {
       child: ValueListenableBuilder<VideoViewParameters>(
         valueListenable: videoViewParametersNotifier,
         builder: (context, videoViewParameters, _) {
-          return Focus(
-            focusNode: videoViewParameters.focusNode ?? widget.focusNode,
-            child: Container(
-              clipBehavior: Clip.none,
-              width: videoViewParameters.width,
-              height: videoViewParameters.height,
-              color: videoViewParameters.fill,
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  ClipRect(
-                    child: FittedBox(
-                      fit: videoViewParameters.fit,
-                      alignment: videoViewParameters.alignment,
-                      child: ValueListenableBuilder<PlatformVideoController?>(
-                        valueListenable: widget.controller.notifier,
-                        builder: (context, notifier, _) => notifier == null
-                            ? const SizedBox.shrink()
-                            : ValueListenableBuilder<int?>(
-                                valueListenable: notifier.id,
-                                builder: (context, id, _) {
-                                  return ValueListenableBuilder<Rect?>(
-                                    valueListenable: notifier.rect,
-                                    builder: (context, rect, _) {
-                                      if (id != null &&
-                                          rect != null &&
-                                          _visible) {
-                                        return SizedBox(
-                                          // Apply aspect ratio if provided.
-                                          width:
-                                              videoViewParameters.aspectRatio ==
-                                                      null
-                                                  ? rect.width
-                                                  : rect.height *
-                                                      videoViewParameters
-                                                          .aspectRatio!,
-                                          height: rect.height,
-                                          child: HtmlElementView(
-                                            key: _key,
-                                            viewType:
-                                                'com.alexmercerind.media_kit_video.$id',
-                                          ),
-                                        );
-                                      }
-                                      return const SizedBox.shrink();
-                                    },
-                                  );
-                                },
-                              ),
-                      ),
+          return Container(
+            clipBehavior: Clip.none,
+            width: videoViewParameters.width,
+            height: videoViewParameters.height,
+            color: videoViewParameters.fill,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                ClipRect(
+                  child: FittedBox(
+                    fit: videoViewParameters.fit,
+                    alignment: videoViewParameters.alignment,
+                    child: ValueListenableBuilder<PlatformVideoController?>(
+                      valueListenable: widget.controller.notifier,
+                      builder: (context, notifier, _) => notifier == null
+                          ? const SizedBox.shrink()
+                          : ValueListenableBuilder<int?>(
+                              valueListenable: notifier.id,
+                              builder: (context, id, _) {
+                                return ValueListenableBuilder<Rect?>(
+                                  valueListenable: notifier.rect,
+                                  builder: (context, rect, _) {
+                                    if (id != null &&
+                                        rect != null &&
+                                        _visible) {
+                                      return SizedBox(
+                                        // Apply aspect ratio if provided.
+                                        width:
+                                            videoViewParameters.aspectRatio ==
+                                                    null
+                                                ? rect.width
+                                                : rect.height *
+                                                    videoViewParameters
+                                                        .aspectRatio!,
+                                        height: rect.height,
+                                        child: HtmlElementView(
+                                          key: _key,
+                                          viewType:
+                                              'com.alexmercerind.media_kit_video.$id',
+                                        ),
+                                      );
+                                    }
+                                    return const SizedBox.shrink();
+                                  },
+                                );
+                              },
+                            ),
                     ),
                   ),
-                  if (videoViewParameters
-                          .subtitleViewConfiguration.visible &&
-                      !(widget.controller.player.platform?.configuration
-                              .libass ??
-                          false))
-                    Positioned.fill(
-                      child: SubtitleView(
-                        controller: widget.controller,
-                        key: _subtitleViewKey,
-                        configuration:
-                            videoViewParameters.subtitleViewConfiguration,
-                      ),
+                ),
+                if (videoViewParameters.subtitleViewConfiguration.visible &&
+                    !(widget.controller.player.platform?.configuration.libass ??
+                        false))
+                  Positioned.fill(
+                    child: SubtitleView(
+                      controller: widget.controller,
+                      key: _subtitleViewKey,
+                      configuration:
+                          videoViewParameters.subtitleViewConfiguration,
                     ),
-                  if (videoViewParameters.controls != null)
-                    Positioned.fill(
-                      child: videoViewParameters.controls!.call(this as dynamic),
-                    ),
-                ],
-              ),
+                  ),
+                if (videoViewParameters.controls != null)
+                  Positioned.fill(
+                    child: videoViewParameters.controls!.call(this as dynamic),
+                  ),
+              ],
             ),
           );
         },

--- a/media_kit_video/lib/src/video_view_parameters.dart
+++ b/media_kit_video/lib/src/video_view_parameters.dart
@@ -27,6 +27,7 @@ class VideoViewParameters {
   final FilterQuality filterQuality;
   final /* VideoControlsBuilder? */ dynamic controls;
   final SubtitleViewConfiguration subtitleViewConfiguration;
+  final FocusNode? focusNode;
 
   /// {@macro video_view_parameters}
   VideoViewParameters({
@@ -39,6 +40,7 @@ class VideoViewParameters {
     required this.filterQuality,
     required this.controls,
     required this.subtitleViewConfiguration,
+    this.focusNode,
   });
 
   VideoViewParameters copyWith({
@@ -55,6 +57,7 @@ class VideoViewParameters {
     SubtitleViewConfiguration? subtitleViewConfiguration,
     Future<void> Function()? onEnterFullscreen,
     Future<void> Function()? onExitFullscreen,
+    FocusNode? focusNode,
   }) {
     return VideoViewParameters(
       width: width ?? this.width,
@@ -67,6 +70,7 @@ class VideoViewParameters {
       controls: controls ?? this.controls,
       subtitleViewConfiguration:
           subtitleViewConfiguration ?? this.subtitleViewConfiguration,
+      focusNode: focusNode ?? this.focusNode,
     );
   }
 
@@ -82,7 +86,8 @@ class VideoViewParameters {
           other.aspectRatio == aspectRatio &&
           other.filterQuality == filterQuality &&
           other.controls == controls &&
-          other.subtitleViewConfiguration == subtitleViewConfiguration;
+          other.subtitleViewConfiguration == subtitleViewConfiguration &&
+          other.focusNode == focusNode;
 
   @override
   int get hashCode =>
@@ -94,5 +99,6 @@ class VideoViewParameters {
       aspectRatio.hashCode ^
       filterQuality.hashCode ^
       controls.hashCode ^
-      subtitleViewConfiguration.hashCode;
+      subtitleViewConfiguration.hashCode ^
+      focusNode.hashCode;
 }


### PR DESCRIPTION
Replaces https://github.com/media-kit/media-kit/pull/1145
@james-lawrence feel free to check it out too

This pull request introduces a `FocusNode` to the `Video` widget and its associated classes to enable keyboard input handling. The changes span multiple files and ensure that the `FocusNode` is properly integrated and propagated through the various components.

Key changes include:

### FocusNode Integration:

* [`media_kit_video/lib/src/video/video_texture.dart`](diffhunk://#diff-58c3e321a1bbd8f45488fca2cfcca646a8a0b61283bb3ba88a44257ef9fb95d1R116-R118): Added a `FocusNode` to the `Video` widget and propagated it through the `VideoState` class. This ensures that the `FocusNode` is properly managed and updated. [[1]](diffhunk://#diff-58c3e321a1bbd8f45488fca2cfcca646a8a0b61283bb3ba88a44257ef9fb95d1R116-R118) [[2]](diffhunk://#diff-58c3e321a1bbd8f45488fca2cfcca646a8a0b61283bb3ba88a44257ef9fb95d1R137) [[3]](diffhunk://#diff-58c3e321a1bbd8f45488fca2cfcca646a8a0b61283bb3ba88a44257ef9fb95d1R193-R196) [[4]](diffhunk://#diff-58c3e321a1bbd8f45488fca2cfcca646a8a0b61283bb3ba88a44257ef9fb95d1L201-R206) [[5]](diffhunk://#diff-58c3e321a1bbd8f45488fca2cfcca646a8a0b61283bb3ba88a44257ef9fb95d1R226) [[6]](diffhunk://#diff-58c3e321a1bbd8f45488fca2cfcca646a8a0b61283bb3ba88a44257ef9fb95d1R267-R269)

* [`media_kit_video/lib/src/video/video_web.dart`](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733R114-R116): Similar changes as in `video_texture.dart`, integrating the `FocusNode` into the web version of the `Video` widget. [[1]](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733R114-R116) [[2]](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733R135) [[3]](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733R194) [[4]](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733R207) [[5]](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733R241-R243) [[6]](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733R270) [[7]](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733L376-R388) [[8]](diffhunk://#diff-2ab281c19a4c79da9d2c1860c507a69b2579b2b9ef3b2d3967f384f81bb17733R457)

* [`media_kit_video/lib/src/video_view_parameters.dart`](diffhunk://#diff-50ee8b9b3163682778bbbf6834fb0b4bd1caf0bf0a193403c383864b0bef232bR30): Updated the `VideoViewParameters` class to include a `FocusNode` and modified the `copyWith` method to handle the new parameter. This ensures that the `FocusNode` is included in the parameter updates. [[1]](diffhunk://#diff-50ee8b9b3163682778bbbf6834fb0b4bd1caf0bf0a193403c383864b0bef232bR30) [[2]](diffhunk://#diff-50ee8b9b3163682778bbbf6834fb0b4bd1caf0bf0a193403c383864b0bef232bR43) [[3]](diffhunk://#diff-50ee8b9b3163682778bbbf6834fb0b4bd1caf0bf0a193403c383864b0bef232bR60) [[4]](diffhunk://#diff-50ee8b9b3163682778bbbf6834fb0b4bd1caf0bf0a193403c383864b0bef232bR73) [[5]](diffhunk://#diff-50ee8b9b3163682778bbbf6834fb0b4bd1caf0bf0a193403c383864b0bef232bL85-R90) [[6]](diffhunk://#diff-50ee8b9b3163682778bbbf6834fb0b4bd1caf0bf0a193403c383864b0bef232bL97-R103)

### Other Adjustments:

* [`media_kit_video/lib/media_kit_video_controls/src/controls/material.dart`](diffhunk://#diff-8d75ad95baeaf6c99394134b7fe3ef3b783f46cf18b0dcb0d849ff3ee306e800R868-R873): Added `FocusNode` handling to the `_MaterialVideoControlsState` class.

* [`media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart`](diffhunk://#diff-138dc7f44e3ec1c9100242fa61b866191ee0432eeccd2aa0173e997eefa1f945R578): Added `FocusNode` handling to the `_MaterialDesktopVideoControlsState` class.

* [`media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart`](diffhunk://#diff-b66aa5bd0f4353cfacf518ae7bb62cc8cfe4359f51e0a5199249cae30f4ba227R72-R73): Updated the `enterFullscreen` method to include the `FocusNode`.