### PR TITLE
fix: upgrade wakelock_plus to a version with a privacy manifest (iOS)

### DIFF
--- a/media_kit_video/pubspec.yaml
+++ b/media_kit_video/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   media_kit: ^1.2.0
 
   synchronized: ^3.1.0
-  wakelock_plus: ^1.1.1
+  wakelock_plus: ^1.1.6
   screen_brightness_android: ^2.0.0
   screen_brightness_platform_interface: ^2.0.0
   volume_controller: ^3.0.2


### PR DESCRIPTION
After submission of our latest update in the app store we got the following message:

> We noticed one or more issues with a recent submission for App Store review for the following app:
> 
> <redacted>
> 
> Although submission for App Store review was successful, you may want to correct the following issues in your next submission for App Store review. Once you've corrected the issues, upload a new binary to App Store Connect.
> 
> ITMS-91061: Missing privacy manifest - Your app includes “Frameworks/wakelock_plus.framework/wakelock_plus”, which includes wakelock, an SDK that was identified in the documentation as a privacy-impacting third-party SDK. Starting February 12, 2025, if a new app includes a privacy-impacting SDK, or an app update adds a new privacy-impacting SDK, the SDK must include a privacy manifest file. Please contact the provider of the SDK that includes this file to get an updated SDK version with a privacy manifest. For more details about this policy, including a list of SDKs that are required to include signatures and manifests, visit: https://developer.apple.com/support/third-party-SDK-requirements.
> 
> Apple Developer Relations

When running `flutter pub deps` I found this was our only dependency causing a transitive dependency on `wakelock_plus`.
This was [fixed in version 1.1.6 of wakelock plus](https://github.com/fluttercommunity/wakelock_plus/pull/23). Bumping the minor version should have fixed it.