### PR TITLE
fix: unique reply user data in mpv_observe_property

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2463,10 +2463,11 @@ class NativePlayer extends PlatformPlayer {
         'secondary-sub-text': generated.mpv_format.MPV_FORMAT_NODE,
       }.forEach(
         (property, format) {
+          final reply = property.hashCode;
           final name = property.toNativeUtf8();
           mpv.mpv_observe_property(
             ctx,
-            0,
+            reply,
             name.cast(),
             format,
           );


### PR DESCRIPTION
It's not a good idea to use 0 for all of them.