### PR TITLE
fixes for URI normalization

### DIFF
--- a/media_kit/lib/src/models/media/media_native.dart
+++ b/media_kit/lib/src/models/media/media_native.dart
@@ -55,8 +55,7 @@ class Media extends Playable {
                   .substring(
                       0, _kFileDescriptorScheme.length.clamp(0, uri.length))
                   .toLowerCase()) {
-        final fd =
-            int.tryParse(uri.substring(_kFileDescriptorScheme.length));
+        final fd = int.tryParse(uri.substring(_kFileDescriptorScheme.length));
         assert(fd != null, 'invalid file descriptor uri, fd is not an integer');
         if (fd != null && fd > 0) {
           await AndroidContentUriProvider.closeFileDescriptor(uri);

--- a/media_kit/lib/src/models/media/media_native.dart
+++ b/media_kit/lib/src/models/media/media_native.dart
@@ -144,10 +144,14 @@ class Media extends Playable {
 
   /// Normalizes the passed URI.
   static String normalizeURI(String uri) {
-    if (uri.startsWith(_kAssetScheme)) {
-      // Handle asset:// scheme. Only for Flutter.
+    // Handle asset:// scheme. Only for Flutter.
+    if (_kAssetScheme ==
+        uri
+            .substring(0, _kAssetScheme.length.clamp(0, uri.length))
+            .toLowerCase()) {
       return AssetLoader.load(uri);
     }
+
     // content:// URI support for Android.
     if (Platform.isAndroid &&
         _kContentScheme ==

--- a/media_kit/lib/src/models/media/media_native.dart
+++ b/media_kit/lib/src/models/media/media_native.dart
@@ -149,19 +149,17 @@ class Media extends Playable {
       return AssetLoader.load(uri);
     }
     // content:// URI support for Android.
-    try {
-      if (Platform.isAndroid) {
-        if (Uri.parse(uri).isScheme('CONTENT')) {
-          final fd = AndroidContentUriProvider.openFileDescriptorSync(uri);
-          if (fd > 0) {
-            return 'fd://$fd';
-          }
-        }
+    if (Platform.isAndroid &&
+        _kContentScheme ==
+            uri
+                .substring(0, _kContentScheme.length.clamp(0, uri.length))
+                .toLowerCase()) {
+      final fd = AndroidContentUriProvider.openFileDescriptorSync(uri);
+      if (fd > 0) {
+        return 'fd://$fd';
       }
-    } catch (exception, stacktrace) {
-      print(exception);
-      print(stacktrace);
     }
+
     // Keep the resulting URI normalization same as used by libmpv internally.
     // [File] or network URIs.
     final parser = URIParser(uri);
@@ -215,6 +213,9 @@ class Media extends Playable {
 
   /// URI scheme used to identify Flutter assets.
   static const String _kAssetScheme = 'asset://';
+
+  /// URI scheme used to identify Android content.
+  static const String _kContentScheme = 'content://';
 
   /// Previously created [Media] instances.
   /// This [HashMap] is used to retrieve previously set [extras] & [httpHeaders].

--- a/media_kit/lib/src/models/media/media_native.dart
+++ b/media_kit/lib/src/models/media/media_native.dart
@@ -56,7 +56,7 @@ class Media extends Playable {
                       0, _kFileDescriptorScheme.length.clamp(0, uri.length))
                   .toLowerCase()) {
         final fd =
-            int.tryParse(uri.substring(0, _kFileDescriptorScheme.length));
+            int.tryParse(uri.substring(_kFileDescriptorScheme.length));
         assert(fd != null, 'invalid file descriptor uri, fd is not an integer');
         if (fd != null && fd > 0) {
           await AndroidContentUriProvider.closeFileDescriptor(uri);

--- a/media_kit/lib/src/models/media/media_web.dart
+++ b/media_kit/lib/src/models/media/media_web.dart
@@ -124,7 +124,11 @@ class Media extends Playable {
 
   /// Normalizes the passed URI.
   static String normalizeURI(String uri) {
-    if (uri.startsWith(_kAssetScheme)) {
+    // ignore scheme case
+    if (_kAssetScheme ==
+        uri
+            .substring(0, _kAssetScheme.length.clamp(0, uri.length))
+            .toLowerCase()) {
       // Handle asset:// scheme. Only for Flutter.
       return AssetLoader.load(uri);
     }

--- a/media_kit/lib/src/player/native/utils/asset_loader.dart
+++ b/media_kit/lib/src/player/native/utils/asset_loader.dart
@@ -82,12 +82,21 @@ class AssetLoader {
   }
 
   static String encodeAssetKey(String uri) {
-    String key = uri.split(_kAssetScheme).last;
-    if (key.startsWith('/')) {
-      key = key.substring(1);
+    var startIdx = 0;
+    // ignore scheme case
+    if (_kAssetScheme ==
+        uri
+            .substring(0, _kAssetScheme.length.clamp(0, uri.length))
+            .toLowerCase()) {
+      startIdx += _kAssetScheme.length;
+    }
+    if (uri[startIdx] == '/') {
+      startIdx++;
     }
     // https://github.com/media-kit/media-kit/issues/121
-    return key.split('/').map((e) => Uri.encodeComponent(e)).join('/');
+    return uri
+        .substring(startIdx)
+        .splitMapJoin('/', onNonMatch: Uri.encodeComponent);
   }
 
   /// URI scheme used to identify Flutter assets.

--- a/media_kit/lib/src/player/web/utils/asset_loader.dart
+++ b/media_kit/lib/src/player/web/utils/asset_loader.dart
@@ -19,17 +19,25 @@ class AssetLoader {
   }
 
   static String encodeAssetKey(String uri) {
-    String key = uri.split(_kAssetScheme).last;
-    if (key.startsWith('/')) {
-      key = key.substring(1);
+    var startIdx = 0;
+    // ignore scheme case
+    if (_kAssetScheme ==
+        uri
+            .substring(0, _kAssetScheme.length.clamp(0, uri.length))
+            .toLowerCase()) {
+      startIdx += _kAssetScheme.length;
     }
+    if (uri[startIdx] == '/') {
+      startIdx++;
+    }
+    final key = uri.substring(startIdx);
 
     // https://github.com/media-kit/media-kit/issues/531
     // https://github.com/media-kit/media-kit/issues/121
     if (kReleaseMode) {
-      return 'assets/${key.split('/').map((e) => Uri.encodeComponent(Uri.encodeComponent(e))).join('/')}';
+      return 'assets/${key.splitMapJoin('/', onNonMatch: (e) => Uri.encodeComponent(Uri.encodeComponent(e)))}';
     }
-    return key.split('/').map(Uri.encodeComponent).join('/');
+    return key.splitMapJoin('/', onNonMatch: Uri.encodeComponent);
   }
 
   /// URI scheme used to identify Flutter assets.


### PR DESCRIPTION
this removes unnecessary Uri.parse calls (which throws with obscure URIs such as `lavf://crypto:file:D:/file.mp3.enc`)
and changes schemes check to ignore scheme casing