### PR TITLE
Fixed the issue that playback did not actually start when playing is …

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -399,7 +399,7 @@ class NativePlayer extends PlatformPlayer {
         playingController.add(false);
       }
 
-      isPlayingStateChangeAllowed = true;
+      isPlayingStateChangeAllowed = state.playing;
       isBufferingStateChangeAllowed = false;
       await _setPropertyFlag('pause', true);
     }
@@ -434,7 +434,7 @@ class NativePlayer extends PlatformPlayer {
         }
       }
 
-      isPlayingStateChangeAllowed = true;
+      isPlayingStateChangeAllowed = state.playing;
       isBufferingStateChangeAllowed = false;
 
       // This condition is specifically for the case when the internal playlist is ended (with [PlaylistLoopMode.none]), and we want to play the playlist again if play/pause is pressed.


### PR DESCRIPTION
1. Play more than 2 audios first.
2. Then pause the playback.
3. Then drag the progress bar to let the Player automatically go to the next.

Then the Player is not playing, but `playing` == true

This PR fixes it.