### PR TITLE
Update real.dart

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2812,7 +2812,7 @@ Uint8List? _screenshot(_ScreenshotData data) {
           }
         case null:
           {
-            image = bytes;
+            image = bytes.sublist(0);
             break;
           }
       }


### PR DESCRIPTION
The data in bytes is a view referencing the internal data of result, so it should not return data that has been or will be freed. Instead, it should return a copy of the data.