### PR TITLE
fix: Ensure pixel_buffer is 4-bits aligned

### DIFF
--- a/media_kit_video/linux/include/media_kit_video/texture_sw.h
+++ b/media_kit_video/linux/include/media_kit_video/texture_sw.h
@@ -37,6 +37,6 @@ gboolean texture_sw_copy_pixels(FlPixelBufferTexture* texture,
 #define SW_RENDERING_MAX_WIDTH 1920
 #define SW_RENDERING_MAX_HEIGHT 1080
 #define SW_RENDERING_PIXEL_BUFFER_SIZE \
-  (SW_RENDERING_MAX_WIDTH) * (SW_RENDERING_MAX_HEIGHT) * (4)
+  (SW_RENDERING_MAX_WIDTH) * (SW_RENDERING_MAX_HEIGHT)
 
 #endif  // TEXTURE_SW_H_

--- a/media_kit_video/linux/video_output.cc
+++ b/media_kit_video/linux/video_output.cc
@@ -19,7 +19,7 @@ struct _VideoOutput {
   GObject parent_instance;
   TextureGL* texture_gl;
   GdkGLContext* gdk_gl_context;
-  guint8* pixel_buffer;
+  guint32* pixel_buffer;
   TextureSW* texture_sw;
   GMutex mutex; /* Only used in S/W rendering. */
   mpv_handle* handle;
@@ -171,7 +171,7 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
   if (!hardware_acceleration_supported) {
     // H/W rendering failed somewhere down the line. Fallback to S/W
     // rendering.
-    self->pixel_buffer = g_new0(guint8, SW_RENDERING_PIXEL_BUFFER_SIZE);
+    self->pixel_buffer = g_new0(guint32, SW_RENDERING_PIXEL_BUFFER_SIZE);
     self->texture_gl = NULL;
     self->gdk_gl_context = NULL;
     self->texture_sw = texture_sw_new(self);
@@ -278,7 +278,7 @@ GdkGLContext* video_output_get_gdk_gl_context(VideoOutput* self) {
 }
 
 guint8* video_output_get_pixel_buffer(VideoOutput* self) {
-  return self->pixel_buffer;
+  return reinterpret_cast<guint8*>(self->pixel_buffer);
 }
 
 gint64 video_output_get_width(VideoOutput* self) {
@@ -324,7 +324,7 @@ gint64 video_output_get_width(VideoOutput* self) {
       return SW_RENDERING_MAX_WIDTH;
     }
     if (height >= SW_RENDERING_MAX_HEIGHT) {
-      return width / height * SW_RENDERING_MAX_HEIGHT;
+      return width * SW_RENDERING_MAX_HEIGHT / height;
     }
   }
 
@@ -374,7 +374,7 @@ gint64 video_output_get_height(VideoOutput* self) {
       return SW_RENDERING_MAX_HEIGHT;
     }
     if (width >= SW_RENDERING_MAX_WIDTH) {
-      return height / width * SW_RENDERING_MAX_WIDTH;
+      return height * SW_RENDERING_MAX_WIDTH / width;
     }
   }
 

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -15,7 +15,7 @@
 #define SW_RENDERING_MAX_WIDTH 1920
 #define SW_RENDERING_MAX_HEIGHT 1080
 #define SW_RENDERING_PIXEL_BUFFER_SIZE \
-  (SW_RENDERING_MAX_WIDTH) * (SW_RENDERING_MAX_HEIGHT) * (4)
+  (SW_RENDERING_MAX_WIDTH) * (SW_RENDERING_MAX_HEIGHT)
 
 VideoOutput::VideoOutput(int64_t handle,
                          VideoOutputConfiguration configuration,
@@ -84,7 +84,7 @@ VideoOutput::VideoOutput(int64_t handle,
       std::cout << "media_kit: VideoOutput: Using S/W rendering." << std::endl;
       // Allocate a "large enough" buffer ahead of time.
       pixel_buffer_ =
-          std::make_unique<uint8_t[]>(SW_RENDERING_PIXEL_BUFFER_SIZE);
+          std::make_unique<uint32_t[]>(SW_RENDERING_PIXEL_BUFFER_SIZE);
       Resize(width_.value_or(1), height_.value_or(1));
       mpv_render_param params[] = {
           {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_SW},
@@ -334,7 +334,7 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
   // S/W
   if (pixel_buffer_ != nullptr) {
     auto pixel_buffer_texture = std::make_unique<FlutterDesktopPixelBuffer>();
-    pixel_buffer_texture->buffer = pixel_buffer_.get();
+    pixel_buffer_texture->buffer = reinterpret_cast<uint8_t*>(pixel_buffer_.get());
     pixel_buffer_texture->width = required_width;
     pixel_buffer_texture->height = required_height;
     pixel_buffer_texture->release_context = nullptr;
@@ -405,7 +405,7 @@ int64_t VideoOutput::GetVideoWidth() {
       return SW_RENDERING_MAX_WIDTH;
     }
     if (height >= SW_RENDERING_MAX_HEIGHT) {
-      return width / height * SW_RENDERING_MAX_HEIGHT;
+      return width * SW_RENDERING_MAX_HEIGHT / height;
     }
   }
 
@@ -454,7 +454,7 @@ int64_t VideoOutput::GetVideoHeight() {
       return SW_RENDERING_MAX_HEIGHT;
     }
     if (width >= SW_RENDERING_MAX_WIDTH) {
-      return height / width * SW_RENDERING_MAX_WIDTH;
+      return height * SW_RENDERING_MAX_WIDTH / width;
     }
   }
 

--- a/media_kit_video/windows/video_output.h
+++ b/media_kit_video/windows/video_output.h
@@ -117,7 +117,7 @@ class VideoOutput {
 
   // S/W rendering.
 
-  std::unique_ptr<uint8_t[]> pixel_buffer_ = nullptr;
+  std::unique_ptr<uint32_t[]> pixel_buffer_ = nullptr;
   std::unordered_map<int64_t, std::unique_ptr<FlutterDesktopPixelBuffer>>
       pixel_buffer_textures_ = {};
 


### PR DESCRIPTION
This PR fix two bugs:
1) Make sure pixel_buffer is 4-bits aligned.
2) Fix texture size caculation wrong.