### PR TITLE
fix[windows]: run method call on main thread

### DIFF
--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -131,7 +131,7 @@ void MediaKitVideoPlugin::HandleMethodCall(
     video_output_manager_->Create(
         handle_value, configuration_value,
         [this, handle = handle_value](auto id, auto width, auto height) {
-          RunOnMainThread([this, handle, id, width, height]() {
+          RunOnMainThread([=]() {
             channel_->InvokeMethod(
                 "VideoOutput.Resize",
                 std::make_unique<flutter::EncodableValue>(flutter::EncodableMap{

--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -59,14 +59,14 @@ void MediaKitVideoPlugin::RunOnMainThread(std::function<void()> task) {
     main_thread_tasks_.push(std::move(task));
   }
 
-  ::PostMessage(flutter_window_, WM_MAIN_THREAD_TASK, 0, 0);
+  ::PostMessage(flutter_window_, kMainThreadTaskMessage, 0, 0);
 }
 
 LRESULT CALLBACK MediaKitVideoPlugin::WindowProcDelegate(HWND hwnd,
                                                          UINT message,
                                                          WPARAM wParam,
                                                          LPARAM lParam) {
-  if (message == WM_MAIN_THREAD_TASK && instance_) {
+  if (message == kMainThreadTaskMessage && instance_) {
     instance_->ProcessMainThreadTasks();
     return 0;
   }

--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -12,6 +12,8 @@
 
 namespace media_kit_video {
 
+MediaKitVideoPlugin* MediaKitVideoPlugin::instance_ = nullptr;
+
 void MediaKitVideoPlugin::RegisterWithRegistrar(
     flutter::PluginRegistrarWindows* registrar) {
   auto plugin = std::make_unique<MediaKitVideoPlugin>(registrar);
@@ -22,6 +24,13 @@ MediaKitVideoPlugin::MediaKitVideoPlugin(
     flutter::PluginRegistrarWindows* registrar)
     : registrar_(registrar),
       video_output_manager_(std::make_unique<VideoOutputManager>(registrar)) {
+  instance_ = this;
+  flutter_window_ =
+      ::GetAncestor(registrar->GetView()->GetNativeWindow(), GA_ROOT);
+  original_window_proc_ = reinterpret_cast<WNDPROC>(
+      ::SetWindowLongPtr(flutter_window_, GWLP_WNDPROC,
+                         reinterpret_cast<LONG_PTR>(WindowProcDelegate)));
+
   channel_ = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
       registrar->messenger(), "com.alexmercerind/media_kit_video",
       &flutter::StandardMethodCodec::GetInstance());
@@ -30,7 +39,64 @@ MediaKitVideoPlugin::MediaKitVideoPlugin(
   });
 }
 
-MediaKitVideoPlugin::~MediaKitVideoPlugin() {}
+MediaKitVideoPlugin::~MediaKitVideoPlugin() {
+  if (flutter_window_ && original_window_proc_) {
+    ::SetWindowLongPtr(flutter_window_, GWLP_WNDPROC,
+                       reinterpret_cast<LONG_PTR>(original_window_proc_));
+  }
+  if (instance_ == this) {
+    instance_ = nullptr;
+  }
+}
+
+void MediaKitVideoPlugin::RunOnMainThread(std::function<void()> task) {
+  if (!flutter_window_) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(main_thread_tasks_mutex_);
+    main_thread_tasks_.push(std::move(task));
+  }
+
+  ::PostMessage(flutter_window_, WM_MAIN_THREAD_TASK, 0, 0);
+}
+
+LRESULT CALLBACK MediaKitVideoPlugin::WindowProcDelegate(HWND hwnd,
+                                                         UINT message,
+                                                         WPARAM wParam,
+                                                         LPARAM lParam) {
+  if (message == WM_MAIN_THREAD_TASK && instance_) {
+    instance_->ProcessMainThreadTasks();
+    return 0;
+  }
+
+  if (instance_ && instance_->original_window_proc_) {
+    return ::CallWindowProc(instance_->original_window_proc_, hwnd, message,
+                            wParam, lParam);
+  }
+
+  return ::DefWindowProc(hwnd, message, wParam, lParam);
+}
+
+void MediaKitVideoPlugin::ProcessMainThreadTasks() {
+  std::queue<std::function<void()>> tasks_to_execute;
+
+  {
+    std::lock_guard<std::mutex> lock(main_thread_tasks_mutex_);
+    tasks_to_execute.swap(main_thread_tasks_);
+  }
+
+  while (!tasks_to_execute.empty()) {
+    auto task = std::move(tasks_to_execute.front());
+    tasks_to_execute.pop();
+
+    try {
+      task();
+    } catch (...) {
+    }
+  }
+}
 
 void MediaKitVideoPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue>& method_call,
@@ -64,42 +130,43 @@ void MediaKitVideoPlugin::HandleMethodCall(
 
     video_output_manager_->Create(
         handle_value, configuration_value,
-        [channel_ptr = channel_.get(), handle = handle_value](
-            auto id, auto width, auto height) {
-          channel_ptr->InvokeMethod(
-              "VideoOutput.Resize",
-              std::make_unique<flutter::EncodableValue>(flutter::EncodableMap{
-                  {
-                      flutter::EncodableValue("handle"),
-                      flutter::EncodableValue(handle),
-                  },
-                  {
-                      flutter::EncodableValue("id"),
-                      flutter::EncodableValue(id),
-                  },
-                  {
-                      flutter::EncodableValue("rect"),
-                      flutter::EncodableValue(flutter::EncodableMap{
-                          {
-                              flutter::EncodableValue("left"),
-                              flutter::EncodableValue(0),
-                          },
-                          {
-                              flutter::EncodableValue("top"),
-                              flutter::EncodableValue(0),
-                          },
-                          {
-                              flutter::EncodableValue("width"),
-                              flutter::EncodableValue(width),
-                          },
-                          {
-                              flutter::EncodableValue("height"),
-                              flutter::EncodableValue(height),
-                          },
-                      }),
-                  },
-              }),
-              nullptr);
+        [this, handle = handle_value](auto id, auto width, auto height) {
+          RunOnMainThread([this, handle, id, width, height]() {
+            channel_->InvokeMethod(
+                "VideoOutput.Resize",
+                std::make_unique<flutter::EncodableValue>(flutter::EncodableMap{
+                    {
+                        flutter::EncodableValue("handle"),
+                        flutter::EncodableValue(handle),
+                    },
+                    {
+                        flutter::EncodableValue("id"),
+                        flutter::EncodableValue(id),
+                    },
+                    {
+                        flutter::EncodableValue("rect"),
+                        flutter::EncodableValue(flutter::EncodableMap{
+                            {
+                                flutter::EncodableValue("left"),
+                                flutter::EncodableValue(0),
+                            },
+                            {
+                                flutter::EncodableValue("top"),
+                                flutter::EncodableValue(0),
+                            },
+                            {
+                                flutter::EncodableValue("width"),
+                                flutter::EncodableValue(width),
+                            },
+                            {
+                                flutter::EncodableValue("height"),
+                                flutter::EncodableValue(height),
+                            },
+                        }),
+                    },
+                }),
+                nullptr);
+          });
         });
     result->Success(flutter::EncodableValue(std::monostate{}));
   } else if (method_call.method_name().compare("VideoOutputManager.Dispose") ==

--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -131,7 +131,7 @@ void MediaKitVideoPlugin::HandleMethodCall(
     video_output_manager_->Create(
         handle_value, configuration_value,
         [this, handle = handle_value](auto id, auto width, auto height) {
-          RunOnMainThread([this, handle, id, width, height]() {
+          RunOnMainThread([&]() {
             channel_->InvokeMethod(
                 "VideoOutput.Resize",
                 std::make_unique<flutter::EncodableValue>(flutter::EncodableMap{

--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -131,7 +131,7 @@ void MediaKitVideoPlugin::HandleMethodCall(
     video_output_manager_->Create(
         handle_value, configuration_value,
         [this, handle = handle_value](auto id, auto width, auto height) {
-          RunOnMainThread([&]() {
+          RunOnMainThread([this, handle, id, width, height]() {
             channel_->InvokeMethod(
                 "VideoOutput.Resize",
                 std::make_unique<flutter::EncodableValue>(flutter::EncodableMap{

--- a/media_kit_video/windows/media_kit_video_plugin.h
+++ b/media_kit_video/windows/media_kit_video_plugin.h
@@ -31,6 +31,8 @@ class MediaKitVideoPlugin : public flutter::Plugin {
   MediaKitVideoPlugin& operator=(const MediaKitVideoPlugin&) = delete;
 
  private:
+  static constexpr UINT kMainThreadTaskMessage = WM_USER + 1001;
+
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
@@ -43,8 +45,6 @@ class MediaKitVideoPlugin : public flutter::Plugin {
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_ =
       nullptr;
   std::unique_ptr<VideoOutputManager> video_output_manager_ = nullptr;
-  
-  static const UINT WM_MAIN_THREAD_TASK = WM_USER + 1001;
   HWND flutter_window_ = nullptr;
   WNDPROC original_window_proc_ = nullptr;
   std::queue<std::function<void()>> main_thread_tasks_;

--- a/media_kit_video/windows/media_kit_video_plugin.h
+++ b/media_kit_video/windows/media_kit_video_plugin.h
@@ -10,6 +10,10 @@
 
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
+#include <Windows.h>
+#include <functional>
+#include <queue>
+#include <mutex>
 
 #include "video_output_manager.h"
 
@@ -31,10 +35,21 @@ class MediaKitVideoPlugin : public flutter::Plugin {
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
+  void RunOnMainThread(std::function<void()> task);
+  static LRESULT CALLBACK WindowProcDelegate(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+  void ProcessMainThreadTasks();
+  
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_ =
       nullptr;
   std::unique_ptr<VideoOutputManager> video_output_manager_ = nullptr;
+  
+  static const UINT WM_MAIN_THREAD_TASK = WM_USER + 1001;
+  HWND flutter_window_ = nullptr;
+  WNDPROC original_window_proc_ = nullptr;
+  std::queue<std::function<void()>> main_thread_tasks_;
+  std::mutex main_thread_tasks_mutex_;
+  static MediaKitVideoPlugin* instance_;
 };
 
 }  // namespace media_kit_video


### PR DESCRIPTION
fixes #1212

This PR builds on the approach introduced in flutter/packages#5884, using PostMessage and a top-level Window Proc Delegate to marshal work onto the main thread that owns the target HWND. It resolves the long-standing warning described in issue #1212.

@alexmercerind 

I’m not deeply versed in the Win32 API, so any corrections, optimizations, or style suggestions are very welcome. Thank you for your feedback!