### PR TITLE
refactor(android): AndroidVideoController impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ migrate_working_dir/
 *.ipr
 *.iws
 .idea/
+.cxx
 
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line

--- a/media_kit_test/lib/common/globals.dart
+++ b/media_kit_test/lib/common/globals.dart
@@ -2,5 +2,9 @@ import 'package:flutter/foundation.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
 final configuration = ValueNotifier<VideoControllerConfiguration>(
-  const VideoControllerConfiguration(enableHardwareAcceleration: true),
+  const VideoControllerConfiguration(
+    // PLEASE USE auto-safe IN PRODUCTION.
+    hwdec: 'auto',
+    enableHardwareAcceleration: true,
+  ),
 );

--- a/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/VideoOutput.java
+++ b/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/VideoOutput.java
@@ -54,9 +54,6 @@ public class VideoOutput implements TextureRegistry.SurfaceProducer.Callback {
 
         surfaceProducer = textureRegistryReference.createSurfaceProducer();
         surfaceProducer.setCallback(this);
-
-        // By default, android.graphics.SurfaceTexture has a size of 1x1.
-        setSurfaceSize(1, 1, true);
     }
 
     public void dispose() {


### PR DESCRIPTION
- Remove unnecessary complexity.
- Fix an issue that caused video output to be stuck on black screen randomly.
- Ensure libmpv does not fallback to `mediacodec-copy` (if `vo=auto` is used) during various operations e.g. opening/switching media in `Player`.

```
PlayerLog(prefix: vd, level: info, text: Using hardware decoding (mediacodec).)
```