### PR TITLE
refactor(windows): dxd11 texture no copy

### DIFF
--- a/media_kit_video/windows/angle_surface_manager.cc
+++ b/media_kit_video/windows/angle_surface_manager.cc
@@ -90,7 +90,7 @@ void ANGLESurfaceManager::Create() {
     throw std::runtime_error("Unable to create ANGLE EGL surface.");
     return;
   }
-  if (internal_handle_ == nullptr || handle_ == nullptr) {
+  if (handle_ == nullptr) {
     throw std::runtime_error("Unable to retrieve Direct3D shared HANDLE.");
     return;
   }
@@ -135,7 +135,6 @@ void ANGLESurfaceManager::CleanUp(bool release_context) {
     d3d_11_texture_2D_->Release();
     d3d_11_texture_2D_ = nullptr;
   }
-  internal_handle_ = nullptr;
   handle_ = nullptr;
 }
 
@@ -210,10 +209,6 @@ bool ANGLESurfaceManager::CreateD3DTexture() {
   hr = resource->GetSharedHandle(&handle_);
   CHECK_HRESULT("IDXGIResource::GetSharedHandle");
   d3d_11_texture_2D_->AddRef();
-  
-  // Also set internal_handle_ to the same handle for EGL binding
-  internal_handle_ = handle_;
-
   std::cout << "media_kit: ANGLESurfaceManager: Created shared texture: "
             << width_ << "x" << height_ << std::endl;
 
@@ -276,7 +271,7 @@ bool ANGLESurfaceManager::CreateAndBindEGLSurface() {
       EGL_NONE,
   };
   surface_ = eglCreatePbufferFromClientBuffer(
-      display_, EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE, internal_handle_,
+      display_, EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE, handle_,
       config_, buffer_attributes);
   if (surface_ == EGL_NO_SURFACE) {
     FAIL("eglCreatePbufferFromClientBuffer");

--- a/media_kit_video/windows/angle_surface_manager.h
+++ b/media_kit_video/windows/angle_surface_manager.h
@@ -68,7 +68,6 @@ class ANGLESurfaceManager {
 
   int32_t width_ = 1;
   int32_t height_ = 1;
-  HANDLE internal_handle_ = nullptr;
   HANDLE handle_ = nullptr;
 
   // Sync |Draw| & |Read| calls.

--- a/media_kit_video/windows/angle_surface_manager.h
+++ b/media_kit_video/windows/angle_surface_manager.h
@@ -76,7 +76,7 @@ class ANGLESurfaceManager {
   // D3D 11
   ID3D11Device* d3d_11_device_ = nullptr;
   ID3D11DeviceContext* d3d_11_device_context_ = nullptr;
-  Microsoft::WRL::ComPtr<ID3D11Texture2D> internal_d3d_11_texture_2D_;
+  // Single shared texture for both ANGLE rendering and Flutter reading
   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d_11_texture_2D_;
   // ANGLE
   EGLSurface surface_ = EGL_NO_SURFACE;


### PR DESCRIPTION
part of #1278

This PR simplifies the Windows implementation by completely removing the intermediate `internal_d3d_11_texture_2D_` texture, thereby avoiding GPU-to-GPU copies. libmpv now renders via ANGLE directly into the texture bound to the Flutter Texture. While this still isn’t truly zero-copy—we still can’t use mpv’s hardware decoders without the copy flag—it’s a significant step forward and delivers tangible performance improvements.