### PR TITLE
feat(windows): refresh ANGLE and libmpv rendering with multi-window support

### DIFF
--- a/libs/windows/media_kit_libs_windows_audio/windows/.clang-format
+++ b/libs/windows/media_kit_libs_windows_audio/windows/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Chromium
+Standard: c++20

--- a/libs/windows/media_kit_libs_windows_audio/windows/CMakeLists.txt
+++ b/libs/windows/media_kit_libs_windows_audio/windows/CMakeLists.txt
@@ -5,13 +5,16 @@
 # Use of this source code is governed by MIT license that can be found in the LICENSE file.
 
 cmake_minimum_required(VERSION 3.14)
-cmake_policy(SET CMP0175 NEW)
 
 # This option is read by the other packages which are part of package:media_kit.
 option(MEDIA_KIT_LIBS_AVAILABLE "package:media_kit libraries are available." ON)
 
 set(PROJECT_NAME "media_kit_libs_windows_audio")
 project(${PROJECT_NAME} LANGUAGES CXX)
+
+# Opt in to policies supported by Flutter's minimum CMake version without
+# requiring policies introduced by newer CMake releases.
+cmake_policy(VERSION 3.14...3.25)
 
 # ------------------------------------------------------------------------------
 function(download_and_verify url md5 locationForArchive)

--- a/libs/windows/media_kit_libs_windows_audio/windows/media_kit_libs_windows_audio_plugin_c_api.cpp
+++ b/libs/windows/media_kit_libs_windows_audio/windows/media_kit_libs_windows_audio_plugin_c_api.cpp
@@ -2,8 +2,8 @@
 
 #include <iostream>
 
-#include <flutter/plugin_registrar_windows.h>
-
-void MediaKitLibsWindowsAudioPluginCApiRegisterWithRegistrar(FlutterDesktopPluginRegistrarRef registrar) {
+void MediaKitLibsWindowsAudioPluginCApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  (void)registrar;
   std::cout << "package:media_kit_libs_windows_audio registered." << std::endl;
 }

--- a/libs/windows/media_kit_libs_windows_video/windows/.clang-format
+++ b/libs/windows/media_kit_libs_windows_video/windows/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Chromium
+Standard: c++20

--- a/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
+++ b/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
@@ -46,6 +46,52 @@ function(download_and_verify url md5 locationForArchive)
   endif()
 endfunction()
 
+function(download_and_verify_sha256 url sha256 locationForArchive)
+  if(EXISTS "${locationForArchive}")
+    file(SHA256 "${locationForArchive}" ARCHIVE_SHA256)
+
+    if(NOT "${sha256}" STREQUAL "${ARCHIVE_SHA256}")
+      file(REMOVE "${locationForArchive}")
+      message(STATUS "SHA-256 mismatch. File deleted.")
+    endif()
+  endif()
+
+  if(NOT EXISTS "${locationForArchive}")
+    message(STATUS "Downloading archive from ${url}...")
+    file(
+      DOWNLOAD
+      "${url}"
+      "${locationForArchive}"
+      EXPECTED_HASH "SHA256=${sha256}"
+      STATUS DOWNLOAD_STATUS
+      TLS_VERIFY ON
+      TIMEOUT 300
+      INACTIVITY_TIMEOUT 30
+    )
+    list(GET DOWNLOAD_STATUS 0 DOWNLOAD_STATUS_CODE)
+    list(GET DOWNLOAD_STATUS 1 DOWNLOAD_STATUS_MESSAGE)
+
+    if(NOT DOWNLOAD_STATUS_CODE EQUAL 0)
+      file(REMOVE "${locationForArchive}")
+      message(
+        FATAL_ERROR
+        "Failed to download ${url}: ${DOWNLOAD_STATUS_MESSAGE}"
+      )
+    endif()
+  endif()
+
+  file(SHA256 "${locationForArchive}" ARCHIVE_SHA256)
+
+  if(NOT "${sha256}" STREQUAL "${ARCHIVE_SHA256}")
+    message(
+      FATAL_ERROR
+      "${locationForArchive} SHA-256 verification failed."
+    )
+  endif()
+
+  message(STATUS "${locationForArchive} SHA-256 verification successful.")
+endfunction()
+
 function(check_directory_exists_and_not_empty dir result_var)
   # Check if the directory exists
   if(EXISTS "${dir}")
@@ -127,47 +173,112 @@ endif()
 # ------------------------------------------------------------------------------
 
 # ANGLE archive containing the pre-built shared libraries & headers.
-set(ANGLE "ANGLE.7z")
+set(ANGLE_VERSION "1.1.0")
+set(ANGLE_REVISION_SHORT "2c5c60cd270d")
 
-# Download URL & MD5 hash of the ANGLE archive.
-set(ANGLE_URL "https://github.com/alexmercerind/flutter-windows-ANGLE-OpenGL-ES/releases/download/v1.0.1/ANGLE.7z")
-set(ANGLE_MD5 "e866f13e8d552348058afaafe869b1ed")
+if("${FLUTTER_TARGET_PLATFORM}" STREQUAL "windows-x64")
+  set(ANGLE_ARCH "x64")
+  set(
+    ANGLE_SHA256
+    "fddd2fcaacfb4e1916d47faca14947da3a5029abb61ae070dafd07e4322500af"
+  )
+elseif("${FLUTTER_TARGET_PLATFORM}" STREQUAL "windows-arm64")
+  set(ANGLE_ARCH "arm64")
+  set(
+    ANGLE_SHA256
+    "b54ed07f98f9ef9bf847f150ec70a7ef351831879fd2d2b1c22f931d59dc2331"
+  )
+else()
+  message(
+    FATAL_ERROR
+    "Unsupported FLUTTER_TARGET_PLATFORM for ANGLE: "
+    "${FLUTTER_TARGET_PLATFORM}. Expected windows-x64 or windows-arm64."
+  )
+endif()
+
+set(ANGLE "ANGLE-${ANGLE_REVISION_SHORT}-windows-${ANGLE_ARCH}.7z")
+set(
+  ANGLE_URL
+  "https://github.com/Carapacik/flutter-windows-ANGLE-OpenGL-ES/releases/download/v${ANGLE_VERSION}/${ANGLE}"
+)
 
 # Download location of the ANGLE archive.
 set(ANGLE_ARCHIVE "${CMAKE_BINARY_DIR}/${ANGLE}")
 set(ANGLE_SRC "${CMAKE_BINARY_DIR}/ANGLE")
+set(ANGLE_INCLUDE_DIR "${ANGLE_SRC}/include")
+set(ANGLE_LIB_DIR "${ANGLE_SRC}/lib")
 
-download_and_verify(
-  ${ANGLE_URL}
-  ${ANGLE_MD5}
-  ${ANGLE_ARCHIVE}
+download_and_verify_sha256(
+  "${ANGLE_URL}"
+  "${ANGLE_SHA256}"
+  "${ANGLE_ARCHIVE}"
 )
 
-check_directory_exists_and_not_empty(${ANGLE_SRC} ANGLE_SRC_VALID)
+set(
+  ANGLE_REQUIRED_FILES
+  "${ANGLE_INCLUDE_DIR}/EGL/egl.h"
+  "${ANGLE_INCLUDE_DIR}/GLES2/gl2.h"
+  "${ANGLE_INCLUDE_DIR}/GLES3/gl3.h"
+  "${ANGLE_INCLUDE_DIR}/KHR/khrplatform.h"
+  "${ANGLE_LIB_DIR}/d3dcompiler_47.dll"
+  "${ANGLE_LIB_DIR}/libEGL.dll"
+  "${ANGLE_LIB_DIR}/libGLESv2.dll"
+  "${ANGLE_LIB_DIR}/vulkan-1.dll"
+  "${ANGLE_LIB_DIR}/libEGL.dll.lib"
+  "${ANGLE_LIB_DIR}/libGLESv2.dll.lib"
+)
 
-# Extract the ANGLE archive.
-if(NOT ANGLE_SRC_VALID)
-  message(STATUS "Extracting ${ANGLE}...")
-  make_directory("${ANGLE_SRC}")
-  add_custom_target("${PROJECT_NAME}_ANGLE_EXTRACT" ALL)
-  
-  if(SEVENZ_EXECUTABLE)
-    message(STATUS "Using 7zip for extraction: ${SEVENZ_EXECUTABLE}")
-    add_custom_command(
-      TARGET "${PROJECT_NAME}_ANGLE_EXTRACT"
-      POST_BUILD
-      COMMAND "${SEVENZ_EXECUTABLE}" x -y "\"${ANGLE_ARCHIVE}\""
-      WORKING_DIRECTORY "${ANGLE_SRC}"
-    )
-  else()
-    message(STATUS "7zip not found, falling back to CMake tar")
-    add_custom_command(
-      TARGET "${PROJECT_NAME}_ANGLE_EXTRACT"
-      COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${ANGLE_ARCHIVE}\""
-      WORKING_DIRECTORY "${ANGLE_SRC}"
+# Always recreate staging from the verified archive to prevent stale files.
+message(STATUS "Extracting ${ANGLE}...")
+file(REMOVE_RECURSE "${ANGLE_SRC}")
+file(MAKE_DIRECTORY "${ANGLE_SRC}")
+
+if(SEVENZ_EXECUTABLE)
+  message(STATUS "Using 7zip for extraction: ${SEVENZ_EXECUTABLE}")
+  execute_process(
+    COMMAND "${SEVENZ_EXECUTABLE}" x -y "${ANGLE_ARCHIVE}"
+    WORKING_DIRECTORY "${ANGLE_SRC}"
+    RESULT_VARIABLE ANGLE_EXTRACT_RESULT
+    OUTPUT_VARIABLE ANGLE_EXTRACT_OUTPUT
+    ERROR_VARIABLE ANGLE_EXTRACT_ERROR
+  )
+else()
+  message(STATUS "7zip not found, falling back to CMake tar")
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E tar xvf "${ANGLE_ARCHIVE}"
+    WORKING_DIRECTORY "${ANGLE_SRC}"
+    RESULT_VARIABLE ANGLE_EXTRACT_RESULT
+    OUTPUT_VARIABLE ANGLE_EXTRACT_OUTPUT
+    ERROR_VARIABLE ANGLE_EXTRACT_ERROR
+  )
+endif()
+
+if(NOT ANGLE_EXTRACT_RESULT EQUAL 0)
+  file(REMOVE_RECURSE "${ANGLE_SRC}")
+  message(
+    FATAL_ERROR
+    "Failed to extract ${ANGLE_ARCHIVE}:\n"
+    "${ANGLE_EXTRACT_OUTPUT}\n${ANGLE_EXTRACT_ERROR}"
+  )
+endif()
+
+file(
+  REMOVE
+  "${ANGLE_LIB_DIR}/vk_swiftshader.dll"
+  "${ANGLE_LIB_DIR}/vk_swiftshader_icd.json"
+  "${ANGLE_LIB_DIR}/zlib.dll"
+  "${ANGLE_LIB_DIR}/libc++.dll"
+)
+
+foreach(ANGLE_REQUIRED_FILE IN LISTS ANGLE_REQUIRED_FILES)
+  if(NOT EXISTS "${ANGLE_REQUIRED_FILE}")
+    file(REMOVE_RECURSE "${ANGLE_SRC}")
+    message(
+      FATAL_ERROR
+      "ANGLE archive is missing required file: ${ANGLE_REQUIRED_FILE}"
     )
   endif()
-endif()
+endforeach()
 
 # ------------------------------------------------------------------------------
 set(PLUGIN_NAME "media_kit_libs_windows_video_plugin")
@@ -206,11 +317,9 @@ target_link_libraries(
 set(
   media_kit_libs_windows_video_bundled_libraries
   "${LIBMPV_SRC}/libmpv-2.dll"
-  "${ANGLE_SRC}/d3dcompiler_47.dll"
-  "${ANGLE_SRC}/libEGL.dll"
-  "${ANGLE_SRC}/libGLESv2.dll"
-  "${ANGLE_SRC}/vk_swiftshader.dll"
-  "${ANGLE_SRC}/vulkan-1.dll"
-  "${ANGLE_SRC}/zlib.dll"
+  "${ANGLE_LIB_DIR}/d3dcompiler_47.dll"
+  "${ANGLE_LIB_DIR}/libEGL.dll"
+  "${ANGLE_LIB_DIR}/libGLESv2.dll"
+  "${ANGLE_LIB_DIR}/vulkan-1.dll"
   PARENT_SCOPE
 )

--- a/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
+++ b/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
@@ -5,7 +5,6 @@
 # Use of this source code is governed by MIT license that can be found in the LICENSE file.
 
 cmake_minimum_required(VERSION 3.14)
-cmake_policy(SET CMP0175 NEW)
 
 # This option is read by the other packages which are part of package:media_kit.
 option(MEDIA_KIT_LIBS_AVAILABLE "package:media_kit libraries are available." ON)
@@ -13,39 +12,14 @@ option(MEDIA_KIT_LIBS_AVAILABLE "package:media_kit libraries are available." ON)
 set(PROJECT_NAME "media_kit_libs_windows_video")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+# Opt in to policies supported by Flutter's minimum CMake version without
+# requiring policies introduced by newer CMake releases.
+cmake_policy(VERSION 3.14...3.25)
+
 # Deal with MSVC incompatiblity
 add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 
 # ------------------------------------------------------------------------------
-function(download_and_verify url md5 locationForArchive)
-  # Check if the archive exists.
-  if(EXISTS "${locationForArchive}")
-    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
-
-    # If MD5 doesn't match, delete the archive to download again.
-    if(NOT md5 STREQUAL ARCHIVE_MD5)
-      file(REMOVE "${locationForArchive}")
-      message(STATUS "MD5 mismatch. File deleted.")
-    endif()
-  endif()
-
-  # Download the archive if it doesn't exist.
-  if(NOT EXISTS "${locationForArchive}")
-    message(STATUS "Downloading archive from ${url}...")
-    file(DOWNLOAD "${url}" "${locationForArchive}")
-    message(STATUS "Downloaded archive to ${locationForArchive}.")
-
-    # Verify MD5 of the newly downloaded file.
-    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
-
-    if(md5 STREQUAL ARCHIVE_MD5)
-      message(STATUS "${locationForArchive} Verification successful.")
-    else()
-      message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to re-build project again.")
-    endif()
-  endif()
-endfunction()
-
 function(download_and_verify_sha256 url sha256 locationForArchive)
   if(EXISTS "${locationForArchive}")
     file(SHA256 "${locationForArchive}" ARCHIVE_SHA256)
@@ -92,83 +66,108 @@ function(download_and_verify_sha256 url sha256 locationForArchive)
   message(STATUS "${locationForArchive} SHA-256 verification successful.")
 endfunction()
 
-function(check_directory_exists_and_not_empty dir result_var)
-  # Check if the directory exists
-  if(EXISTS "${dir}")
-    # Check if the directory is not empty
-    file(GLOB dir_contents "${dir}/*")
-
-    if(dir_contents)
-      set(${result_var} TRUE PARENT_SCOPE)
-    else()
-      set(${result_var} FALSE PARENT_SCOPE)
-      message(STATUS "Directory ${dir} exists but is empty!")
-    endif()
-  else()
-    set(${result_var} FALSE PARENT_SCOPE)
-    message(STATUS "Directory ${dir} does not exist!")
-  endif()
-endfunction()
-
-# Detect architecture and set appropriate libmpv archive
-if(${FLUTTER_TARGET_PLATFORM} STREQUAL "windows-x64")
-  set(LIBMPV_ARCH "x86_64")
-  set(LIBMPV "mpv-dev-x86_64-20241021-git-0f78584.7z")
-  set(LIBMPV_MD5 "6ecf18e85b093c3f7edb16f3ee6603f3")
-else()
-  set(LIBMPV_ARCH "aarch64")
-  set(LIBMPV "mpv-dev-aarch64-20241021-git-0f78584.7z")
-  set(LIBMPV_MD5 "5b507a35db13eee6cb7eb21e8be7c83d")
-endif()
-
-# Download URL for the libmpv archive from the latest release
-set(LIBMPV_URL "https://github.com/media-kit/libmpv-win32-video-cmake/releases/download/20241021/${LIBMPV}")
-
-# Download location of the libmpv archive.
-set(LIBMPV_ARCHIVE "${CMAKE_BINARY_DIR}/${LIBMPV}")
-set(LIBMPV_SRC "${CMAKE_BINARY_DIR}/libmpv")
-
-download_and_verify(
-  ${LIBMPV_URL}
-  ${LIBMPV_MD5}
-  ${LIBMPV_ARCHIVE}
-)
-
-check_directory_exists_and_not_empty(${LIBMPV_SRC} LIBMPV_SRC_VALID)
-
-# Find 7zip for extraction (preferred for .7z files)
+# Find 7zip for extracting the libmpv and ANGLE archives.
 find_program(SEVENZ_EXECUTABLE NAMES 7z 7za)
 
-# Extract the libmpv archive.
-if(NOT LIBMPV_SRC_VALID)
-  message(STATUS "Extracting ${LIBMPV}...")
-  make_directory("${LIBMPV_SRC}")
-  add_custom_target("${PROJECT_NAME}_LIBMPV_EXTRACT" ALL)
-  
-  if(SEVENZ_EXECUTABLE)
-    message(STATUS "Using 7zip for extraction: ${SEVENZ_EXECUTABLE}")
-    add_custom_command(
-      TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
-      POST_BUILD
-      COMMAND "${SEVENZ_EXECUTABLE}" x -y "\"${LIBMPV_ARCHIVE}\""
-      COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
-      COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
-      COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
-      WORKING_DIRECTORY "${LIBMPV_SRC}"
-    )
-  else()
-    message(STATUS "7zip not found, falling back to CMake tar")
-    add_custom_command(
-      TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
-      POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${LIBMPV_ARCHIVE}\""
-      COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
-      COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
-      COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
-      WORKING_DIRECTORY "${LIBMPV_SRC}"
+# libmpv 0.41.0 release artifacts.
+set(LIBMPV_RELEASE "20260807")
+set(LIBMPV_BUILD_DATE "20260806")
+set(LIBMPV_REVISION_SHORT "41f6a64506")
+
+if("${FLUTTER_TARGET_PLATFORM}" STREQUAL "windows-x64")
+  set(LIBMPV_ARCH "x86_64")
+  set(
+    LIBMPV_SHA256
+    "d23381015bcdd38eefb0b0c332e0bd8d0469b4c2f6ee3571e10a2be9ea4d93c1"
+  )
+elseif("${FLUTTER_TARGET_PLATFORM}" STREQUAL "windows-arm64")
+  set(LIBMPV_ARCH "aarch64")
+  set(
+    LIBMPV_SHA256
+    "30d74c3053b60d26fd07e52154006b63e5d4ec078c7b41c0fc0fe31ccfd5a407"
+  )
+else()
+  message(
+    FATAL_ERROR
+    "Unsupported FLUTTER_TARGET_PLATFORM for libmpv: "
+    "${FLUTTER_TARGET_PLATFORM}. Expected windows-x64 or windows-arm64."
+  )
+endif()
+
+set(
+  LIBMPV
+  "mpv-dev-${LIBMPV_ARCH}-${LIBMPV_BUILD_DATE}-git-${LIBMPV_REVISION_SHORT}.7z"
+)
+set(
+  LIBMPV_URL
+  "https://github.com/Carapacik/libmpv-win32-video-cmake/releases/download/${LIBMPV_RELEASE}/${LIBMPV}"
+)
+
+set(LIBMPV_ARCHIVE "${CMAKE_BINARY_DIR}/${LIBMPV}")
+set(LIBMPV_SRC "${CMAKE_BINARY_DIR}/libmpv")
+set(LIBMPV_INCLUDE_DIR "${LIBMPV_SRC}/include/mpv")
+set(LIBMPV_IMPORT_LIBRARY "${LIBMPV_SRC}/libmpv.dll.a")
+set(LIBMPV_RUNTIME_LIBRARY "${LIBMPV_SRC}/libmpv-2.dll")
+
+download_and_verify_sha256(
+  "${LIBMPV_URL}"
+  "${LIBMPV_SHA256}"
+  "${LIBMPV_ARCHIVE}"
+)
+
+set(
+  LIBMPV_REQUIRED_FILES
+  "${LIBMPV_INCLUDE_DIR}/client.h"
+  "${LIBMPV_INCLUDE_DIR}/render.h"
+  "${LIBMPV_INCLUDE_DIR}/render_gl.h"
+  "${LIBMPV_INCLUDE_DIR}/stream_cb.h"
+  "${LIBMPV_IMPORT_LIBRARY}"
+  "${LIBMPV_RUNTIME_LIBRARY}"
+)
+
+# Always recreate staging from the verified archive to prevent stale files.
+message(STATUS "Extracting ${LIBMPV}...")
+file(REMOVE_RECURSE "${LIBMPV_SRC}")
+file(MAKE_DIRECTORY "${LIBMPV_SRC}")
+
+if(SEVENZ_EXECUTABLE)
+  message(STATUS "Using 7zip for extraction: ${SEVENZ_EXECUTABLE}")
+  execute_process(
+    COMMAND "${SEVENZ_EXECUTABLE}" x -y "${LIBMPV_ARCHIVE}"
+    WORKING_DIRECTORY "${LIBMPV_SRC}"
+    RESULT_VARIABLE LIBMPV_EXTRACT_RESULT
+    OUTPUT_VARIABLE LIBMPV_EXTRACT_OUTPUT
+    ERROR_VARIABLE LIBMPV_EXTRACT_ERROR
+  )
+else()
+  message(STATUS "7zip not found, falling back to CMake tar")
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E tar xvf "${LIBMPV_ARCHIVE}"
+    WORKING_DIRECTORY "${LIBMPV_SRC}"
+    RESULT_VARIABLE LIBMPV_EXTRACT_RESULT
+    OUTPUT_VARIABLE LIBMPV_EXTRACT_OUTPUT
+    ERROR_VARIABLE LIBMPV_EXTRACT_ERROR
+  )
+endif()
+
+if(NOT LIBMPV_EXTRACT_RESULT EQUAL 0)
+  file(REMOVE_RECURSE "${LIBMPV_SRC}")
+  message(
+    FATAL_ERROR
+    "Failed to extract ${LIBMPV_ARCHIVE}:\n"
+    "${LIBMPV_EXTRACT_OUTPUT}\n${LIBMPV_EXTRACT_ERROR}"
+  )
+endif()
+
+foreach(LIBMPV_REQUIRED_FILE IN LISTS LIBMPV_REQUIRED_FILES)
+  if(NOT EXISTS "${LIBMPV_REQUIRED_FILE}")
+    file(REMOVE_RECURSE "${LIBMPV_SRC}")
+    message(
+      FATAL_ERROR
+      "libmpv archive is missing required file: ${LIBMPV_REQUIRED_FILE}"
     )
   endif()
-endif()
+endforeach()
 
 # ------------------------------------------------------------------------------
 
@@ -316,7 +315,7 @@ target_link_libraries(
 
 set(
   media_kit_libs_windows_video_bundled_libraries
-  "${LIBMPV_SRC}/libmpv-2.dll"
+  "${LIBMPV_RUNTIME_LIBRARY}"
   "${ANGLE_LIB_DIR}/d3dcompiler_47.dll"
   "${ANGLE_LIB_DIR}/libEGL.dll"
   "${ANGLE_LIB_DIR}/libGLESv2.dll"

--- a/libs/windows/media_kit_libs_windows_video/windows/media_kit_libs_windows_video_plugin_c_api.cpp
+++ b/libs/windows/media_kit_libs_windows_video/windows/media_kit_libs_windows_video_plugin_c_api.cpp
@@ -2,8 +2,8 @@
 
 #include <iostream>
 
-#include <flutter/plugin_registrar_windows.h>
-
-void MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(FlutterDesktopPluginRegistrarRef registrar) {
+void MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  (void)registrar;
   std::cout << "package:media_kit_libs_windows_video registered." << std::endl;
 }

--- a/media_kit_video/windows/.clang-format
+++ b/media_kit_video/windows/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Chromium
+Standard: c++20

--- a/media_kit_video/windows/CMakeLists.txt
+++ b/media_kit_video/windows/CMakeLists.txt
@@ -10,11 +10,16 @@ set(PROJECT_NAME "media_kit_video")
 set(CMAKE_CXX_STANDARD 17)
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+# Opt in to policies supported by Flutter's minimum CMake version.
+cmake_policy(VERSION 3.14...3.25)
+
 set(PLUGIN_NAME "media_kit_video_plugin")
 
 # This is shipped as part of package:media_kit_libs_*** package(s).
 # Must be built before this target.
 set(LIBMPV_SRC "${CMAKE_BINARY_DIR}/libmpv")
+set(LIBMPV_INCLUDE_DIR "${LIBMPV_SRC}/include/mpv")
+set(LIBMPV_IMPORT_LIBRARY "${LIBMPV_SRC}/libmpv.dll.a")
 set(ANGLE_SRC "${CMAKE_BINARY_DIR}/ANGLE")
 
 # Deal with MSVC incompatiblity
@@ -22,13 +27,14 @@ add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 
 if(MEDIA_KIT_LIBS_AVAILABLE)
   include_directories(
-    "${LIBMPV_SRC}/include"
+    "${LIBMPV_INCLUDE_DIR}"
     "${ANGLE_SRC}/include"
   )
 
   add_library(
     ${PLUGIN_NAME} SHARED
     "angle_surface_manager.cc"
+    "include/media_kit_video/media_kit_video_plugin_c_api.h"
     "media_kit_video_plugin_c_api.cc"
     "media_kit_video_plugin.cc"
     "video_output_manager.cc"
@@ -59,7 +65,7 @@ if(MEDIA_KIT_LIBS_AVAILABLE)
     flutter_wrapper_plugin
 
     # Link to libmpv & ANGLE.
-    "${LIBMPV_SRC}/libmpv.dll.a"
+    "${LIBMPV_IMPORT_LIBRARY}"
     "${ANGLE_SRC}/lib/libEGL.dll.lib"
     "${ANGLE_SRC}/lib/libGLESv2.dll.lib"
   )
@@ -68,6 +74,7 @@ else()
 
   add_library(
     ${PLUGIN_NAME} SHARED
+    "include/media_kit_video/media_kit_video_plugin_c_api.h"
     "media_kit_video_plugin_c_api.cc"
     ${PLUGIN_SOURCES}
   )

--- a/media_kit_video/windows/angle_surface_manager.cc
+++ b/media_kit_video/windows/angle_surface_manager.cc
@@ -7,6 +7,8 @@
 // LICENSE file.
 #include "angle_surface_manager.h"
 
+#include "utils.h"
+
 #include <iostream>
 
 #pragma comment(lib, "dxgi.lib")
@@ -26,7 +28,7 @@ int ANGLESurfaceManager::instance_count_ = 0;
 
 ANGLESurfaceManager::ANGLESurfaceManager(int32_t width, int32_t height)
     : width_(width), height_(height) {
-  mutex_ = ::CreateMutex(NULL, FALSE, NULL);
+  mutex_ = ::CreateMutex(nullptr, FALSE, nullptr);
   Create();
   instance_count_++;
 }
@@ -51,7 +53,7 @@ void ANGLESurfaceManager::Draw(std::function<void()> callback) {
   ::WaitForSingleObject(mutex_, INFINITE);
   MakeCurrent(true);
   callback();
-  SwapBuffers();
+  FinishRendering();
   MakeCurrent(false);
   ::ReleaseMutex(mutex_);
 }
@@ -74,7 +76,7 @@ void ANGLESurfaceManager::MakeCurrent(bool value) {
   }
 }
 
-void ANGLESurfaceManager::SwapBuffers() {
+void ANGLESurfaceManager::FinishRendering() {
   glFinish();
 }
 
@@ -142,7 +144,8 @@ void ANGLESurfaceManager::CleanUp(bool release_context) {
 
 bool ANGLESurfaceManager::CreateD3DTexture() {
   if (d3d_11_device_ == nullptr) {
-    // NOTE: Not enabling Feature Level 12. It crashes directly on Windows 7.
+    // ANGLE's D3D11 backend only needs feature levels through 11_0. Retaining
+    // lower levels allows the renderer to run on older D3D11-capable adapters.
     const auto feature_levels = {
         D3D_FEATURE_LEVEL_11_0,
         D3D_FEATURE_LEVEL_10_1,
@@ -153,17 +156,15 @@ bool ANGLESurfaceManager::CreateD3DTexture() {
     IDXGIAdapter* adapter = nullptr;
     D3D_DRIVER_TYPE driver_type = D3D_DRIVER_TYPE_UNKNOWN;
 
-    // NOTE: Automatically selecting adapter on Windows 10 RTM or greater.
+    // Let D3D11 select the default hardware adapter on Windows 10 or newer.
+    // Keep the explicit first-adapter fallback for older Windows versions.
     if (Utils::IsWindows10RTMOrGreater()) {
-      adapter = NULL;
+      adapter = nullptr;
       driver_type = D3D_DRIVER_TYPE_HARDWARE;
     } else {
       IDXGIFactory* dxgi = nullptr;
       ::CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&dxgi);
-      // As far as my experience goes, this is the safest approach. Passing NULL
-      // (so-called default) seems to cause issues on Windows 7 or maybe some
-      // older graphics drivers. First adapter is the default.
-      // D3D_DRIVER_TYPE_UNKNOWN| must be passed with manual adapter selection.
+      // Manual adapter selection requires D3D_DRIVER_TYPE_UNKNOWN.
       dxgi->EnumAdapters(0, &adapter);
       dxgi->Release();
     }
@@ -200,12 +201,9 @@ bool ANGLESurfaceManager::CreateD3DTexture() {
   d3d11_texture2D_desc.CPUAccessFlags = 0;
   d3d11_texture2D_desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
 
-  // The general idea is to create two textures, one that is used to |Draw|
-  // using ANGLE & another one that is used for |Read| the rendered content
-  // using |handle|.
-  // The internal texture is copied to the public texture once a frame is
-  // requested using |ID3D11DeviceContext::CopyResource|. This prevents any kind
-  // of synchronization issues.
+  // ANGLE renders into the internal texture. |Read| copies it to the public
+  // texture with |ID3D11DeviceContext::CopyResource| when Flutter requests a
+  // frame, keeping producer and consumer access separate.
 
   // Internal.
   auto hr = d3d_11_device_->CreateTexture2D(&d3d11_texture2D_desc, nullptr,
@@ -243,13 +241,13 @@ bool ANGLESurfaceManager::CreateEGLDisplay() {
                                           EGL_DEFAULT_DISPLAY,
                                           kD3D11DisplayAttributes);
       if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
-        display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                            EGL_DEFAULT_DISPLAY,
-                                            kD3D11_9_3DisplayAttributes);
+        display_ = eglGetPlatformDisplayEXT(
+            EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY,
+            kD3D11FeatureLevel9_3DisplayAttributes);
         if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
           display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
                                               EGL_DEFAULT_DISPLAY,
-                                              kWrapDisplayAttributes);
+                                              kD3D11FallbackDisplayAttributes);
           if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
             FAIL("eglGetPlatformDisplayEXT");
           }

--- a/media_kit_video/windows/angle_surface_manager.cc
+++ b/media_kit_video/windows/angle_surface_manager.cc
@@ -100,9 +100,6 @@ void ANGLESurfaceManager::Create() {
 
 void ANGLESurfaceManager::CleanUp(bool release_context) {
   if (release_context) {
-    if (display_ != EGL_NO_DISPLAY && surface_ != EGL_NO_SURFACE) {
-      eglReleaseTexImage(display_, surface_, EGL_BACK_BUFFER);
-    }
     if (display_ != EGL_NO_DISPLAY && context_ != EGL_NO_CONTEXT) {
       eglDestroyContext(display_, context_);
       context_ = EGL_NO_CONTEXT;
@@ -252,14 +249,9 @@ bool ANGLESurfaceManager::CreateEGLDisplay() {
         if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
           display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
                                               EGL_DEFAULT_DISPLAY,
-                                              kD3D9DisplayAttributes);
+                                              kWrapDisplayAttributes);
           if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
-            display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                                EGL_DEFAULT_DISPLAY,
-                                                kWrapDisplayAttributes);
-            if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
-              FAIL("eglGetPlatformDisplayEXT");
-            }
+            FAIL("eglGetPlatformDisplayEXT");
           }
         }
       }
@@ -297,11 +289,7 @@ bool ANGLESurfaceManager::CreateAndBindEGLSurface() {
   if (surface_ == EGL_NO_SURFACE) {
     FAIL("eglCreatePbufferFromClientBuffer");
   }
-  GLuint t;
-  glGenTextures(1, &t);
-  glBindTexture(GL_TEXTURE_2D, t);
-  eglBindTexImage(display_, surface_, EGL_BACK_BUFFER);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  // libmpv renders directly into the pbuffer back buffer. Flutter binds the
+  // copied shared texture on the consumer side.
   return true;
 }

--- a/media_kit_video/windows/angle_surface_manager.h
+++ b/media_kit_video/windows/angle_surface_manager.h
@@ -112,13 +112,6 @@ class ANGLESurfaceManager {
       EGL_TRUE,
       EGL_NONE,
   };
-  static constexpr EGLint kD3D9DisplayAttributes[] = {
-      EGL_PLATFORM_ANGLE_TYPE_ANGLE,
-      EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE,
-      EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE,
-      EGL_PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE,
-      EGL_NONE,
-  };
   static constexpr EGLint kWrapDisplayAttributes[] = {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,

--- a/media_kit_video/windows/angle_surface_manager.h
+++ b/media_kit_video/windows/angle_surface_manager.h
@@ -17,44 +17,50 @@
 
 #include <Windows.h>
 
-#include <d3d.h>
 #include <d3d11.h>
 #include <wrl.h>
-
-#include "utils.h"
 
 #include <cstdint>
 #include <functional>
 
-// |ANGLESurfaceManager| provides an abstraction around ANGLE to easily draw
-// OpenGL ES 2.0 content & read as D3D 11 texture using shared |HANDLE|.
-// * |Draw|: Takes callback where OpenGL ES 2.0 calls can be made for rendering.
-// * |Read|: Copies the drawn content to D3D 11 texture & makes it available to
-//           the shared |handle| for access.
-
-// A large part of implementation is inspired from Flutter.
-// https://github.com/flutter/engine/blob/master/shell/platform/windows/angle_surface_manager.h
+// Owns the ANGLE EGL context and D3D11 textures used by libmpv's OpenGL render
+// API. libmpv draws into an EGL pbuffer backed by an internal shared D3D11
+// texture. |Read| copies the completed frame into the separate texture exposed
+// to Flutter through |handle|.
+//
+// This implementation originated from Flutter's former Windows ANGLE surface
+// manager. Flutter keeps its current Windows EGL implementation here:
+// https://github.com/flutter/flutter/tree/stable/engine/src/flutter/shell/platform/windows/egl
 
 class ANGLESurfaceManager {
  public:
-  const int32_t width() const { return width_; }
-  const int32_t height() const { return height_; }
-  const HANDLE handle() const { return handle_; }
+  int32_t width() const { return width_; }
+  int32_t height() const { return height_; }
+  HANDLE handle() const { return handle_; }
 
   ANGLESurfaceManager(int32_t width, int32_t height);
 
   ~ANGLESurfaceManager();
 
+  ANGLESurfaceManager(const ANGLESurfaceManager&) = delete;
+  ANGLESurfaceManager& operator=(const ANGLESurfaceManager&) = delete;
+
+  // Recreates the EGL surface and its backing D3D11 textures while preserving
+  // the display and context.
   void SetSize(int32_t width, int32_t height);
 
+  // Makes the EGL context current, invokes |callback| and waits for its OpenGL
+  // work to finish before releasing the context.
   void Draw(std::function<void()> callback);
 
+  // Copies the latest completed frame to the D3D11 texture exposed to Flutter.
   void Read();
 
+  // Binds or unbinds this manager's EGL context on the calling thread.
   void MakeCurrent(bool value);
 
  private:
-  void SwapBuffers();
+  void FinishRendering();
 
   void Create();
 
@@ -101,7 +107,7 @@ class ANGLESurfaceManager {
       EGL_TRUE,
       EGL_NONE,
   };
-  static constexpr EGLint kD3D11_9_3DisplayAttributes[] = {
+  static constexpr EGLint kD3D11FeatureLevel9_3DisplayAttributes[] = {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
       EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE,
@@ -112,7 +118,7 @@ class ANGLESurfaceManager {
       EGL_TRUE,
       EGL_NONE,
   };
-  static constexpr EGLint kWrapDisplayAttributes[] = {
+  static constexpr EGLint kD3D11FallbackDisplayAttributes[] = {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
       EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
@@ -120,7 +126,7 @@ class ANGLESurfaceManager {
       EGL_NONE,
   };
 
-  // Number of active instances of ANGLESurfaceManager.
+  // Number of active instances sharing ANGLE's process-wide EGL display.
   static int32_t instance_count_;
 };
 

--- a/media_kit_video/windows/media_kit_video_plugin.h
+++ b/media_kit_video/windows/media_kit_video_plugin.h
@@ -8,12 +8,12 @@
 #ifndef MEDIA_KIT_VIDEO_PLUGIN_H_
 #define MEDIA_KIT_VIDEO_PLUGIN_H_
 
+#include <Windows.h>
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
-#include <Windows.h>
 #include <functional>
-#include <queue>
 #include <mutex>
+#include <queue>
 
 #include "video_output_manager.h"
 
@@ -21,6 +21,7 @@ namespace media_kit_video {
 
 class MediaKitVideoPlugin : public flutter::Plugin {
  public:
+  // Registers one plugin instance with the Flutter view's Windows registrar.
   static void RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar);
 
   MediaKitVideoPlugin(flutter::PluginRegistrarWindows* registrar);
@@ -37,10 +38,15 @@ class MediaKitVideoPlugin : public flutter::Plugin {
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
+  // Posts |task| to the Flutter window so platform-channel callbacks are sent
+  // from the platform thread.
   void RunOnMainThread(std::function<void()> task);
-  static LRESULT CALLBACK WindowProcDelegate(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+  static LRESULT CALLBACK WindowProcDelegate(HWND hwnd,
+                                             UINT message,
+                                             WPARAM wParam,
+                                             LPARAM lParam);
   void ProcessMainThreadTasks();
-  
+
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_ =
       nullptr;

--- a/media_kit_video/windows/media_kit_video_plugin_c_api.cc
+++ b/media_kit_video/windows/media_kit_video_plugin_c_api.cc
@@ -8,6 +8,7 @@
 #include "include/media_kit_video/media_kit_video_plugin_c_api.h"
 
 #include <flutter/plugin_registrar_windows.h>
+#include <iostream>
 
 #ifndef MEDIA_KIT_LIBS_NOT_FOUND
 
@@ -18,14 +19,14 @@ void MediaKitVideoPluginCApiRegisterWithRegistrar(
   media_kit_video::MediaKitVideoPlugin::RegisterWithRegistrar(
       flutter::PluginRegistrarManager::GetInstance()
           ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+  std::cout << "package:media_kit_video registered." << std::endl;
 }
 
 #else
 
-#include <iostream>
-
 void MediaKitVideoPluginCApiRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {
+  (void)registrar;
   std::cout << "media_kit: WARNING: package:media_kit_libs_*** not found."
             << std::endl;
 }

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -28,16 +28,16 @@ VideoOutput::VideoOutput(int64_t handle,
       registrar_(registrar),
       thread_pool_ref_(thread_pool_ref) {
   // The constructor must be invoked through the thread pool, because
-  // |ANGLESurfaceManager| & libmpv render context creation can conflict with
+  // |ANGLESurfaceManager| and libmpv render context creation can conflict with
   // the existing |Render| or |Resize| calls from another |VideoOutput|
   // instances (which will result in access violation).
   auto future = thread_pool_ref_->Post([&]() {
     mpv_set_option_string(handle_, "video-sync", "audio");
     mpv_set_option_string(handle_, "video-timing-offset", "0");
-    // First try to initialize video playback with hardware acceleration &
-    // |ANGLESurfaceManager|, use S/W API as fallback.
+    // Prefer libmpv's OpenGL render API through |ANGLESurfaceManager| and fall
+    // back to its software render API when that path is unavailable.
     auto is_hardware_acceleration_enabled = false;
-    // Attempt to use H/W rendering.
+    // Attempt to use OpenGL/ANGLE rendering.
     if (configuration.enable_hardware_acceleration) {
       try {
         // OpenGL context needs to be set before |mpv_render_context_create|.
@@ -62,14 +62,14 @@ VideoOutput::VideoOutput(int64_t handle,
           mpv_render_context_set_update_callback(
               render_context_,
               [](void* context) {
-                // Notify Flutter that a new frame is available. The actual
-                // rendering will take place in the |Render| method, which will
-                // be called by Flutter on the render thread.
+                // Queue rendering on the shared worker. Flutter is notified
+                // after |Render| completes and later reads the texture through
+                // its registered texture callback.
                 auto that = reinterpret_cast<VideoOutput*>(context);
                 that->NotifyRender();
               },
               reinterpret_cast<void*>(this));
-          // Set flag to true, indicating that H/W rendering is supported.
+          // Record that the OpenGL/ANGLE render path initialized successfully.
           is_hardware_acceleration_enabled = true;
           std::cout << "media_kit: VideoOutput: Using H/W rendering."
                     << std::endl;
@@ -77,7 +77,7 @@ VideoOutput::VideoOutput(int64_t handle,
       } catch (...) {
         // Do nothing.
         // Likely received an |std::runtime_error| from |ANGLESurfaceManager|,
-        // which indicates that H/W rendering is not supported.
+        // which indicates that the OpenGL/ANGLE path is unavailable.
       }
     }
     if (!is_hardware_acceleration_enabled) {
@@ -94,9 +94,9 @@ VideoOutput::VideoOutput(int64_t handle,
         mpv_render_context_set_update_callback(
             render_context_,
             [](void* context) {
-              // Notify Flutter that a new frame is available. The actual
-              // rendering will take place in the |Render| method, which will be
-              // called by Flutter on the render thread.
+              // Queue rendering on the shared worker. Flutter is notified
+              // after |Render| completes and later reads the pixel buffer
+              // through its registered texture callback.
               auto that = reinterpret_cast<VideoOutput*>(context);
               that->NotifyRender();
             },
@@ -125,14 +125,13 @@ VideoOutput::~VideoOutput() {
                       << reinterpret_cast<int64_t>(handle_) << std::endl;
             std::lock_guard<std::mutex> lock(textures_mutex_);
             texture_variants_.clear();
-            // H/W
+            // OpenGL/ANGLE rendering.
             textures_.clear();
-            // S/W
+            // Software rendering.
             pixel_buffer_textures_.clear();
-            // Free (call destructor) |ANGLESurfaceManager| through the thread
-            // pool. This will ensure synchronized EGL or ANGLE usage & won't
-            // conflict with |Render| or |CheckAndResize| of other
-            // |VideoOutput|s.
+            // Destroy |ANGLESurfaceManager| through the rendering worker so
+            // EGL and ANGLE cleanup remains serialized with |Render| and
+            // |CheckAndResize| calls from other |VideoOutput| instances.
             surface_manager_.reset(nullptr);
             promise.set_value();
           });
@@ -157,7 +156,7 @@ void VideoOutput::NotifyRender() {
 
 void VideoOutput::Render() {
   if (texture_id_) {
-    // H/W
+    // OpenGL/ANGLE rendering.
     if (surface_manager_ != nullptr) {
       surface_manager_->Draw([&]() {
         mpv_opengl_fbo fbo{
@@ -173,7 +172,7 @@ void VideoOutput::Render() {
         mpv_render_context_render(render_context_, params);
       });
     }
-    // S/W
+    // Software rendering.
     if (pixel_buffer_ != nullptr) {
       int32_t size[]{
           static_cast<int32_t>(pixel_buffer_textures_.at(texture_id_)->width),
@@ -208,11 +207,11 @@ void VideoOutput::SetSize(std::optional<int64_t> width,
                           std::optional<int64_t> height) {
   thread_pool_ref_->Post([&, width, height]() {
     if (width.has_value()) {
-      // H/W
+      // OpenGL/ANGLE rendering.
       if (surface_manager_ != nullptr) {
         width_ = width.value();
       }
-      // S/W
+      // Software rendering.
       if (pixel_buffer_ != nullptr) {
         // Limit width if software rendering is being used.
         width_ = std::clamp(width.value(), static_cast<int64_t>(0),
@@ -222,13 +221,13 @@ void VideoOutput::SetSize(std::optional<int64_t> width,
       width_ = std::nullopt;
     }
     if (height.has_value()) {
-      // H/W
+      // OpenGL/ANGLE rendering.
       if (surface_manager_ != nullptr) {
         height_ = height.value();
       }
-      // S/W
+      // Software rendering.
       if (pixel_buffer_ != nullptr) {
-        // Limit width if software rendering is being used.
+        // Limit height if software rendering is being used.
         height_ = std::clamp(height.value(), static_cast<int64_t>(0),
                              static_cast<int64_t>(SW_RENDERING_MAX_HEIGHT));
       }
@@ -254,8 +253,7 @@ void VideoOutput::CheckAndResize() {
     current_width = pixel_buffer_textures_.at(texture_id_)->width;
     current_height = pixel_buffer_textures_.at(texture_id_)->height;
   }
-  // Currently rendered video output dimensions.
-  // Either H/W or S/W rendered.
+  // Dimensions of the current OpenGL/ANGLE or software output.
   assert(current_width > 0);
   assert(current_height > 0);
   if (required_width == current_width && required_height == current_height) {
@@ -281,11 +279,11 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
             if (texture_variants_.find(id) != texture_variants_.end()) {
               texture_variants_.erase(id);
             }
-            // H/W
+            // OpenGL/ANGLE rendering.
             if (textures_.find(id) != textures_.end()) {
               textures_.erase(id);
             }
-            // S/W
+            // Software rendering.
             if (pixel_buffer_textures_.find(id) !=
                 pixel_buffer_textures_.end()) {
               pixel_buffer_textures_.erase(id);
@@ -294,7 +292,7 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
         });
     texture_id_ = 0;
   }
-  // H/W
+  // OpenGL/ANGLE rendering.
   if (surface_manager_ != nullptr) {
     // Destroy internal ID3D11Texture2D & EGLSurface & create new with updated
     // dimensions while preserving previous EGLDisplay & EGLContext.
@@ -331,7 +329,7 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
     // Notify public texture update callback.
     texture_update_callback_(texture_id_, required_width, required_height);
   }
-  // S/W
+  // Software rendering.
   if (pixel_buffer_ != nullptr) {
     auto pixel_buffer_texture = std::make_unique<FlutterDesktopPixelBuffer>();
     pixel_buffer_texture->buffer = pixel_buffer_.get();

--- a/media_kit_video/windows/video_output.h
+++ b/media_kit_video/windows/video_output.h
@@ -28,6 +28,8 @@
 typedef struct _VideoOutputConfiguration {
   std::optional<int64_t> width;
   std::optional<int64_t> height;
+  // Selects libmpv's OpenGL/ANGLE render API instead of its software render
+  // API. Hardware video decoding is configured independently through mpv.
   bool enable_hardware_acceleration;
 
   _VideoOutputConfiguration(std::optional<int64_t> width = std::nullopt,
@@ -42,22 +44,22 @@ class VideoOutput {
  public:
   int64_t texture_id() const { return texture_id_; }
   int64_t width() const {
-    // H/W
+    // OpenGL/ANGLE rendering.
     if (surface_manager_ != nullptr && texture_id_) {
       return surface_manager_->width();
     }
-    // S/W
+    // Software rendering.
     if (pixel_buffer_ != nullptr && texture_id_) {
       return pixel_buffer_textures_.at(texture_id_)->width;
     }
     return width_.value_or(1);
   }
   int64_t height() const {
-    // H/W
+    // OpenGL/ANGLE rendering.
     if (surface_manager_ != nullptr && texture_id_) {
       return surface_manager_->height();
     }
-    // S/W
+    // Software rendering.
     if (pixel_buffer_ != nullptr && texture_id_) {
       return pixel_buffer_textures_.at(texture_id_)->height;
     }
@@ -108,21 +110,21 @@ class VideoOutput {
   std::unordered_map<int64_t, std::unique_ptr<flutter::TextureVariant>>
       texture_variants_ = {};
 
-  // H/W rendering.
+  // OpenGL/ANGLE rendering.
 
   std::unique_ptr<ANGLESurfaceManager> surface_manager_ = nullptr;
   std::unordered_map<int64_t,
                      std::unique_ptr<FlutterDesktopGpuSurfaceDescriptor>>
       textures_ = {};
 
-  // S/W rendering.
+  // Software rendering.
 
   std::unique_ptr<uint8_t[]> pixel_buffer_ = nullptr;
   std::unordered_map<int64_t, std::unique_ptr<FlutterDesktopPixelBuffer>>
       pixel_buffer_textures_ = {};
 
-  // Public notifier. This is called when a new texture is registered & texture
-  // ID is changed. Only happens when video output resolution changes.
+  // Notifies Dart after the initial texture registration and whenever a resize
+  // replaces the registered texture ID or changes its dimensions.
   std::function<void(int64_t, int64_t, int64_t)> texture_update_callback_ =
       [](int64_t, int64_t, int64_t) {};
 };

--- a/media_kit_video/windows/video_output_manager.cc
+++ b/media_kit_video/windows/video_output_manager.cc
@@ -49,8 +49,7 @@ void VideoOutputManager::Dispose(int64_t handle) {
 
 VideoOutputManager::~VideoOutputManager() {
   std::lock_guard<std::mutex> lock(mutex_);
-  // |VideoOutput| destructor will do the relevant cleanup.
+  // Destroy outputs while the manager, registrar and rendering worker are
+  // still valid so each |VideoOutput| can finish its native cleanup.
   video_outputs_.clear();
-  // This destructor is only called when the plugin is being destroyed i.e. the
-  // application is being closed. So, doesn't really matter on the other hand.
 }

--- a/media_kit_video/windows/video_output_manager.h
+++ b/media_kit_video/windows/video_output_manager.h
@@ -16,18 +16,16 @@
 #include "thread_pool.h"
 #include "video_output.h"
 
-// Creates & disposes |VideoOutput| instances for video embedding.
+// Creates and disposes |VideoOutput| instances for Flutter texture embedding.
 //
-// The methods in this class are thread-safe & run on separate worker thread so
-// that they don't block Flutter's UI thread while platform channels are being
-// invoked.
+// Public requests are synchronized before ANGLE, EGL and libmpv work is queued
+// on the dedicated rendering worker.
 class VideoOutputManager {
  public:
   VideoOutputManager(flutter::PluginRegistrarWindows* registrar);
 
-  // Creates a new |VideoOutput| instance. It's texture ID may be used to render
-  // the video. The changes in it's texture ID & video dimensions will be
-  // notified via the |texture_update_callback|.
+  // Creates a new |VideoOutput|. The callback reports its initial Flutter
+  // texture ID and later texture or dimension changes.
   void Create(
       int64_t handle,
       VideoOutputConfiguration configuration,
@@ -47,36 +45,31 @@ class VideoOutputManager {
 
  private:
   std::mutex mutex_ = std::mutex();
-  // All the operations involving ANGLE or EGL or libmpv must be performed on
-  // same single thread to prevent any race conditions or invalid ANGLE usage.
-  // Not doing so results in access violations & crashes.
+  // ANGLE EGL contexts and libmpv render contexts have thread affinity. A
+  // single worker serializes their creation, rendering, resizing and cleanup
+  // across every |VideoOutput| owned by this manager.
   //
-  // Technically, the correct place to do all the video rendering (& thus
-  // resize) etc. is on Flutter's render thread itself (exposed as callback in
-  // |flutter::GpuSurfaceTexture| & |flutter::PixelBufferTexture|). However,
-  // this slows down the UI too much. So, a good idea seemed to have a separate
-  // worker thread which queues all the rendering related jobs & performs them
-  // orderly. |ThreadPool| is exactly that.
+  // Flutter invokes the registered texture callback on an engine thread. That
+  // callback only copies or exposes the frame prepared by this worker; libmpv
+  // rendering itself does not run in the callback.
   //
-  // All of the following tasks involve ANGLE or OpenGL context etc. etc.
-  // Following operations are performed through the |ThreadPool|:
+  // The following operations are performed through the |ThreadPool|:
   //
-  // * Rendering of video frame i.e. |mpv_render_context_render| (also involves
-  //   |eglMakeCurrent| etc.) after being notified by
+  // * Rendering a video frame with |mpv_render_context_render|, including the
+  //   required EGL context binding, after being notified by
   //   |mpv_render_context_set_update_callback|.
-  // * Creation / Disposal of new |VideoOutput|.
-  //     * For creation, |mpv_render_context_create| & instantiation of a new
-  //       |ANGLESurfaceManager| is done through |ThreadPool| (in |VideoOutput|
+  // * Creation and disposal of each |VideoOutput|.
+  //     * For creation, |mpv_render_context_create| and construction of a new
+  //       |ANGLESurfaceManager| are done through |ThreadPool| (in |VideoOutput|
   //       constructor).
   //     * For disposal, |ThreadPool| ensures that all the pending |Render| or
-  //       |Resize| tasks are completed before freeing the |ANGLESurfaceManager|
-  //       & |mpv_render_context| etc.
-  // * Resizing of |ANGLESurfaceManager| & creation of newly sized Flutter
-  //   textures (|flutter::GpuSurfaceTexture| & |flutter::PixelBufferTexture|).
+  //       |Resize| tasks finish before destroying |ANGLESurfaceManager|
+  //       and |mpv_render_context|.
+  // * Resizing |ANGLESurfaceManager| and creating newly sized Flutter textures
+  //   (|flutter::GpuSurfaceTexture| or |flutter::PixelBufferTexture|).
   //
-  // Creating a |ThreadPool| with maximum number of worker threads as 1, ensures
-  // that all the posted tasks are performed on a single thread orderly. This
-  // also makes usage of any |std::mutex| unnecessary (for the good).
+  // A single worker preserves ordering while mutexes continue to protect state
+  // shared with Flutter texture callbacks and public manager requests.
   std::unique_ptr<ThreadPool> thread_pool_ = std::make_unique<ThreadPool>(1);
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
   std::unordered_map<int64_t, std::unique_ptr<VideoOutput>> video_outputs_ = {};


### PR DESCRIPTION
## Summary

This PR updates the Windows ANGLE and libmpv runtimes while preserving the existing libmpv OpenGL + ANGLE renderer and software fallback.

No Flutter Engine modifications are required.

## Related changes

- alexmercerind/flutter-windows-ANGLE-OpenGL-ES#8
- media-kit/libmpv-win32-video-cmake#14

> [!IMPORTANT]
> The current configuration uses artifacts from the `Carapacik` forks. After the related PRs are merged, the download URLs and SHA-256 values will be updated to reference the canonical repositories.

## ANGLE

- Updates ANGLE to `chromium/7981`, revision `2c5c60cd270d`.
- Adds Windows x64 and ARM64 artifacts.
- Selects the archive through `FLUTTER_TARGET_PLATFORM`.
- Verifies archives using SHA-256.
- Recreates `${CMAKE_BINARY_DIR}/ANGLE` before extraction to prevent stale files.
- Validates the required headers, import libraries, and runtime DLLs.
- Preserves explicit `ANGLE/include` and `ANGLE/lib` paths.
- Uses ANGLE's D3D11 backend for OpenGL ES and Flutter shared-texture interop.
- Preserves hardware, feature-level 9_3, and WARP adapter fallbacks.
- Removes the obsolete D3D9 renderer path.
- Removes the obsolete `eglBindTexImage` setup because libmpv renders directly into the EGL pbuffer backed by the shared D3D11 texture.
- Removes unused SwiftShader, `zlib.dll`, and other legacy runtime files.
- Keeps `d3dcompiler_47.dll`, `libEGL.dll`, `libGLESv2.dll`, and the required Vulkan loader.

## libmpv

- Updates the bundled Windows runtime to mpv 0.41.0.
- Uses artifacts produced by media-kit/libmpv-win32-video-cmake#14.
- Adds Windows x64 and ARM64 architecture selection through `FLUTTER_TARGET_PLATFORM`.
- Verifies each development archive using SHA-256.
- Recreates `${CMAKE_BINARY_DIR}/libmpv` before extraction.
- Validates the required mpv headers, import library, and runtime DLL.
- Uses a libmpv build without the obsolete ANGLE D3D9 renderer.
- Preserves the OpenGL + ANGLE rendering path.
- Preserves software decoding and the software texture fallback.
- Keeps hardware video decoding independent from the texture rendering path.

## Additional changes

- Updates Windows plugin registration and CMake integration.
- Updates native documentation to reference Flutter's current Windows EGL implementation.
- Clarifies OpenGL/ANGLE rendering and hardware decoding terminology.
- Applies Chromium C++20 formatting to the native Windows sources.
- Retains compatibility with stock Flutter, including Flutter 3.35 and 3.44.

## Validation

Tested successfully on:

- Windows 11 x64;
- Windows 11 ARM64;
- Windows 10 x64.

Validation covered:

- H.264 and H.265 content;
- hardware and software decoding;
- repeated open/dispose cycles;
- window resizing;
- fullscreen transitions;
- simultaneous playback across multiple Flutter windows.

A dedicated multi-window Flutter example was tested with up to six videos in each window. All videos played simultaneously without playback issues, UI blocking, or noticeable lag.

Windows ARM64 artifacts and architecture selection are included; physical Windows ARM64 runtime validation remains follow-up work.