### PR TITLE
media_kit_video/windows: 1. WndProc 已改为按 HWND -> MediaKitVideoPlugin …

### DIFF
--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -12,7 +12,9 @@
 
 namespace media_kit_video {
 
-MediaKitVideoPlugin* MediaKitVideoPlugin::instance_ = nullptr;
+std::unordered_map<HWND, MediaKitVideoPlugin*>
+    MediaKitVideoPlugin::instances_;
+std::mutex MediaKitVideoPlugin::instances_mutex_;
 
 void MediaKitVideoPlugin::RegisterWithRegistrar(
     flutter::PluginRegistrarWindows* registrar) {
@@ -24,12 +26,15 @@ MediaKitVideoPlugin::MediaKitVideoPlugin(
     flutter::PluginRegistrarWindows* registrar)
     : registrar_(registrar),
       video_output_manager_(std::make_unique<VideoOutputManager>(registrar)) {
-  instance_ = this;
   flutter_window_ =
       ::GetAncestor(registrar->GetView()->GetNativeWindow(), GA_ROOT);
   original_window_proc_ = reinterpret_cast<WNDPROC>(
       ::SetWindowLongPtr(flutter_window_, GWLP_WNDPROC,
                          reinterpret_cast<LONG_PTR>(WindowProcDelegate)));
+  {
+    std::lock_guard<std::mutex> lock(instances_mutex_);
+    instances_[flutter_window_] = this;
+  }
 
   channel_ = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
       registrar->messenger(), "com.alexmercerind/media_kit_video",
@@ -40,12 +45,13 @@ MediaKitVideoPlugin::MediaKitVideoPlugin(
 }
 
 MediaKitVideoPlugin::~MediaKitVideoPlugin() {
+  {
+    std::lock_guard<std::mutex> lock(instances_mutex_);
+    instances_.erase(flutter_window_);
+  }
   if (flutter_window_ && original_window_proc_) {
     ::SetWindowLongPtr(flutter_window_, GWLP_WNDPROC,
                        reinterpret_cast<LONG_PTR>(original_window_proc_));
-  }
-  if (instance_ == this) {
-    instance_ = nullptr;
   }
 }
 
@@ -66,13 +72,22 @@ LRESULT CALLBACK MediaKitVideoPlugin::WindowProcDelegate(HWND hwnd,
                                                          UINT message,
                                                          WPARAM wParam,
                                                          LPARAM lParam) {
-  if (message == kMainThreadTaskMessage && instance_) {
-    instance_->ProcessMainThreadTasks();
+  MediaKitVideoPlugin* instance = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(instances_mutex_);
+    const auto it = instances_.find(hwnd);
+    if (it != instances_.end()) {
+      instance = it->second;
+    }
+  }
+
+  if (message == kMainThreadTaskMessage && instance) {
+    instance->ProcessMainThreadTasks();
     return 0;
   }
 
-  if (instance_ && instance_->original_window_proc_) {
-    return ::CallWindowProc(instance_->original_window_proc_, hwnd, message,
+  if (instance && instance->original_window_proc_) {
+    return ::CallWindowProc(instance->original_window_proc_, hwnd, message,
                             wParam, lParam);
   }
 

--- a/media_kit_video/windows/media_kit_video_plugin.h
+++ b/media_kit_video/windows/media_kit_video_plugin.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <queue>
 #include <mutex>
+#include <unordered_map>
 
 #include "video_output_manager.h"
 
@@ -49,7 +50,8 @@ class MediaKitVideoPlugin : public flutter::Plugin {
   WNDPROC original_window_proc_ = nullptr;
   std::queue<std::function<void()>> main_thread_tasks_;
   std::mutex main_thread_tasks_mutex_;
-  static MediaKitVideoPlugin* instance_;
+  static std::unordered_map<HWND, MediaKitVideoPlugin*> instances_;
+  static std::mutex instances_mutex_;
 };
 
 }  // namespace media_kit_video

--- a/media_kit_video/windows/utils.cc
+++ b/media_kit_video/windows/utils.cc
@@ -14,10 +14,9 @@ typedef LONG NTSTATUS, *PNTSTATUS;
 typedef NTSTATUS(WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
 
 void Utils::EnterNativeFullscreen(HWND window) {
-  if (fullscreen_) {
+  if (fullscreen_states_.find(window) != fullscreen_states_.end()) {
     return;
   }
-  fullscreen_ = true;
 
   // The primary idea here is to revolve around |WS_OVERLAPPEDWINDOW| &
   // detect/set fullscreen based on it. In the window procedure, this is
@@ -27,13 +26,15 @@ void Utils::EnterNativeFullscreen(HWND window) {
   // |WM_NCCALCSIZE|.
 
   auto style = ::GetWindowLongPtr(window, GWL_STYLE);
+  auto& state = fullscreen_states_[window];
+  state.style = style;
   if (style & WS_OVERLAPPEDWINDOW) {
     auto monitor = MONITORINFO{};
     auto placement = WINDOWPLACEMENT{};
     monitor.cbSize = sizeof(MONITORINFO);
     placement.length = sizeof(WINDOWPLACEMENT);
     ::GetWindowPlacement(window, &placement);
-    rect_before_fullscreen_ = RECT{
+    state.rect_before_fullscreen = RECT{
         placement.rcNormalPosition.left,
         placement.rcNormalPosition.top,
         placement.rcNormalPosition.right,
@@ -42,6 +43,7 @@ void Utils::EnterNativeFullscreen(HWND window) {
     ::GetMonitorInfo(::MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST),
                      &monitor);
     ::SetWindowLongPtr(window, GWL_STYLE, style & ~WS_OVERLAPPEDWINDOW);
+    state.changed_style = true;
     ::SetWindowPos(window, HWND_TOP, monitor.rcMonitor.left,
                    monitor.rcMonitor.top,
                    monitor.rcMonitor.right - monitor.rcMonitor.left,
@@ -51,14 +53,15 @@ void Utils::EnterNativeFullscreen(HWND window) {
 }
 
 void Utils::ExitNativeFullscreen(HWND window) {
-  if (!fullscreen_) {
+  const auto iterator = fullscreen_states_.find(window);
+  if (iterator == fullscreen_states_.end()) {
     return;
   }
-  fullscreen_ = false;
+  const auto state = iterator->second;
+  fullscreen_states_.erase(iterator);
 
-  auto style = ::GetWindowLongPtr(window, GWL_STYLE);
-  if (!(style & WS_OVERLAPPEDWINDOW)) {
-    ::SetWindowLongPtr(window, GWL_STYLE, style | WS_OVERLAPPEDWINDOW);
+  if (state.changed_style) {
+    ::SetWindowLongPtr(window, GWL_STYLE, state.style);
     if (::IsZoomed(window)) {
       // Refresh the parent window.
       ::SetWindowPos(window, nullptr, 0, 0, 0, 0,
@@ -73,11 +76,11 @@ void Utils::ExitNativeFullscreen(HWND window) {
                      SWP_NOACTIVATE | SWP_NOZORDER);
     } else {
       ::SetWindowPos(
-          window, nullptr, rect_before_fullscreen_.left,
-          rect_before_fullscreen_.top,
-          rect_before_fullscreen_.right - rect_before_fullscreen_.left,
-          rect_before_fullscreen_.bottom - rect_before_fullscreen_.top,
-          SWP_NOACTIVATE | SWP_NOZORDER);
+          window, nullptr, state.rect_before_fullscreen.left,
+          state.rect_before_fullscreen.top,
+          state.rect_before_fullscreen.right - state.rect_before_fullscreen.left,
+          state.rect_before_fullscreen.bottom - state.rect_before_fullscreen.top,
+          SWP_NOACTIVATE | SWP_NOZORDER | SWP_FRAMECHANGED);
     }
   }
 }
@@ -102,6 +105,4 @@ bool Utils::IsWindows10RTMOrGreater() {
   return GetWindowsVersion().dwBuildNumber >= 10240;
 }
 
-bool Utils::fullscreen_ = false;
-
-RECT Utils::rect_before_fullscreen_ = RECT{};
+std::unordered_map<HWND, Utils::FullscreenState> Utils::fullscreen_states_;

--- a/media_kit_video/windows/utils.h
+++ b/media_kit_video/windows/utils.h
@@ -10,6 +10,7 @@
 #define UTILS_H_
 
 #include <cstdint>
+#include <unordered_map>
 
 #include <Windows.h>
 
@@ -26,8 +27,13 @@ class Utils {
  private:
   static constexpr auto kFlutterViewWindowClassName = L"FLUTTERVIEW";
 
-  static bool fullscreen_;
-  static RECT rect_before_fullscreen_;
+  struct FullscreenState {
+    LONG_PTR style;
+    RECT rect_before_fullscreen;
+    bool changed_style = false;
+  };
+
+  static std::unordered_map<HWND, FullscreenState> fullscreen_states_;
 };
 
 #endif  // UTILS_H_

--- a/media_kit_video/windows/video_output_manager.cc
+++ b/media_kit_video/windows/video_output_manager.cc
@@ -8,6 +8,8 @@
 
 #include "video_output_manager.h"
 
+std::mutex VideoOutputManager::global_mutex_;
+
 VideoOutputManager::VideoOutputManager(
     flutter::PluginRegistrarWindows* registrar)
     : registrar_(registrar) {}
@@ -17,7 +19,7 @@ void VideoOutputManager::Create(
     VideoOutputConfiguration configuration,
     std::function<void(int64_t, int64_t, int64_t)> texture_update_callback) {
   std::thread([=]() {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(global_mutex_);
     if (video_outputs_.find(handle) == video_outputs_.end()) {
       auto instance = std::make_unique<VideoOutput>(
           handle, configuration, registrar_, thread_pool_.get());
@@ -31,7 +33,7 @@ void VideoOutputManager::SetSize(int64_t handle,
                                  std::optional<int64_t> width,
                                  std::optional<int64_t> height) {
   std::thread([=]() {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(global_mutex_);
     if (video_outputs_.find(handle) != video_outputs_.end()) {
       video_outputs_[handle]->SetSize(width, height);
     }
@@ -40,7 +42,7 @@ void VideoOutputManager::SetSize(int64_t handle,
 
 void VideoOutputManager::Dispose(int64_t handle) {
   std::thread([=]() {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(global_mutex_);
     if (video_outputs_.find(handle) != video_outputs_.end()) {
       video_outputs_.erase(handle);
     }
@@ -48,7 +50,7 @@ void VideoOutputManager::Dispose(int64_t handle) {
 }
 
 VideoOutputManager::~VideoOutputManager() {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(global_mutex_);
   // |VideoOutput| destructor will do the relevant cleanup.
   video_outputs_.clear();
   // This destructor is only called when the plugin is being destroyed i.e. the

--- a/media_kit_video/windows/video_output_manager.h
+++ b/media_kit_video/windows/video_output_manager.h
@@ -46,7 +46,7 @@ class VideoOutputManager {
   ~VideoOutputManager();
 
  private:
-  std::mutex mutex_ = std::mutex();
+  static std::mutex global_mutex_;
   // All the operations involving ANGLE or EGL or libmpv must be performed on
   // same single thread to prevent any race conditions or invalid ANGLE usage.
   // Not doing so results in access violations & crashes.


### PR DESCRIPTION
media_kit_video/windows: 
1. WndProc 已改为按 HWND -> MediaKitVideoPlugin 映射，不再使用单例 instance_。
2. VideoOutputManager 已使用进程级 global_mutex_